### PR TITLE
Single Stage Detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Object detection models detect the presence of multiple objects in an image and 
 |Model Class |Reference |Description |
 |-|-|-|
 |<b>[Tiny_YOLOv2](tiny_yolov2)</b>|[Redmon et al.](https://arxiv.org/pdf/1612.08242.pdf)|Deep CNN model for Object Detection|
-|<b>SSD</b>|[Liu et al.](https://arxiv.org/abs/1512.02325)|[contribute](contribute.md)|
+|<b>[SSD](ssd)</b>|[Liu et al.](https://arxiv.org/abs/1512.02325)|Deep CNN model for Object Detection|
 |<b>Faster-RCNN</b>|[Ren et al.](https://arxiv.org/abs/1506.01497)|[contribute](contribute.md)|
 |<b>Mask-RCNN</b>|[He et al.](https://arxiv.org/abs/1703.06870)|[contribute](contribute.md)|
 |<b>YOLO v2</b>|[Redmon et al.](https://arxiv.org/abs/1612.08242)|[contribute](contribute.md)|

--- a/ssd/README.md
+++ b/ssd/README.md
@@ -1,0 +1,74 @@
+# Single Stage Detector
+
+## Description
+Description of model
+
+## Model
+
+|Model        |Download  |Checksum| Download (with sample test data)|ONNX version|Opset version|Accuracy |
+|-------------|:--------------|:--------------|:--------------|:--------------|:--------------|:--------------|
+|SSD       |ONNX Model download link with size  | MD5 checksum for the ONNX model| tar file containing ONNX model and synthetic test data (in .pb format)|1.4.1 |10 |mAP of 0.195 |
+
+
+
+<hr>
+
+## Inference
+
+### Input to model
+Image shape `(1x3x1200x1200)`
+
+### Preprocessing steps
+The images have to be loaded in to a range of [0, 1], resized to (1200, 1200) with bilinear interpolation and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225]. The transformation should preferrably happen at preprocessing.
+
+The following code shows how to preprocess a NCHW tensor:
+
+```python
+import numpy as np
+from PIL import Image
+
+def preprocess(img_path):
+    input_shape = (1, 3, 1200, 1200)
+    img = Image.open(img_path)
+    img = img.resize((1200, 1200), Image.BILINEAR)
+    img_data = np.array(img)
+    mean_vec = np.array([0.485, 0.456, 0.406])
+    stddev_vec = np.array([0.229, 0.224, 0.225])
+    norm_img_data = np.zeros(img_data.shape).astype('float32')
+    for i in range(img_data.shape[0]):
+        norm_img_data[:,i,:,:] = (img_data[:,i,:,:]/255 - mean_vec[i]) / stddev_vec[i]
+    return norm_img_data
+```
+
+### Output of model
+The model has 3 outputs.
+boxes: `(1x'nbox'x4)`
+labels: `(1x'nbox')`
+scores: `(1x'nbox')`
+
+<!-- ### Postprocessing steps
+Post processing and meaning of output
+<hr> -->
+
+## Dataset (Train and validation)
+The SSD model was trained on 2017 COCO train data set - using mlperf/training/single_stage_detector repo , compute mAP on 2017 COCO val data set.
+<hr>
+
+## Validation accuracy
+Metric is COCO box mAP (averaged over IoU of 0.5:0.95), computed over 2017 COCO val data.
+mAP of 0.195
+<hr>
+
+## Publication/Attribution
+Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott Reed, Cheng-Yang Fu, Alexander C. Berg. SSD: Single Shot MultiBox Detector. In the Proceedings of the European Conference on Computer Vision (ECCV), 2016.
+
+Backbone is ResNet34 pretrained on ILSVRC 2012 (from torchvision). Modifications to the backbone networks: remove conv_5x residual blocks, change the first 3x3 convolution of the conv_4x block from stride 2 to stride1 (this increases the resolution of the feature map to which detector heads are attached), attach all 6 detector heads to the output of the last conv_4x residual block. Thus detections are attached to 38x38, 19x19, 10x10, 5x5, 3x3, and 1x1 feature maps. Convolutions in the detector layers are followed by batch normalization layers.
+<hr>
+
+## References
+This model is converted from mlperf/inference [repository](https://github.com/mlperf/inference/tree/master/cloud/single_stage_detector) with modifications.
+<hr>
+
+## License
+Apache License 2.0
+<hr>

--- a/ssd/README.md
+++ b/ssd/README.md
@@ -7,7 +7,7 @@ Description of model
 
 |Model        |Download  |Checksum| Download (with sample test data)|ONNX version|Opset version|Accuracy |
 |-------------|:--------------|:--------------|:--------------|:--------------|:--------------|:--------------|
-|SSD       |ONNX Model download link with size  | MD5 checksum for the ONNX model| tar file containing ONNX model and synthetic test data (in .pb format)|1.4.1 |10 |mAP of 0.195 |
+|SSD       |[80.4 MB](https://onnxzoo.blob.core.windows.net/models/opset_10/ssd/ssd.onnx) | [MD5](https://onnxzoo.blob.core.windows.net/models/opset_10/ssd/ssd-md5.txt) | [78.5 MB](https://onnxzoo.blob.core.windows.net/models/opset_10/ssd/ssd.tar.gz) |1.4.1 |10 |mAP of 0.195 |
 
 
 
@@ -66,7 +66,7 @@ Backbone is ResNet34 pretrained on ILSVRC 2012 (from torchvision). Modifications
 <hr>
 
 ## References
-This model is converted from mlperf/inference [repository](https://github.com/mlperf/inference/tree/master/cloud/single_stage_detector) with modifications.
+This model is converted from mlperf/inference [repository](https://github.com/mlperf/inference/tree/master/cloud/single_stage_detector) with modifications in [repository](https://github.com/BowenBao/inference/tree/master/cloud/single_stage_detector/pytorch).
 <hr>
 
 ## License

--- a/ssd/README.md
+++ b/ssd/README.md
@@ -1,7 +1,7 @@
 # Single Stage Detector
 
 ## Description
-Description of model
+This model is a real-time neural network for object detection that detects 80 different classes.
 
 ## Model
 
@@ -35,7 +35,7 @@ def preprocess(img_path):
     mean_vec = np.array([0.485, 0.456, 0.406])
     stddev_vec = np.array([0.229, 0.224, 0.225])
     norm_img_data = np.zeros(img_data.shape).astype('float32')
-    for i in range(img_data.shape[0]):
+    for i in range(img_data.shape[1]):
         norm_img_data[:,i,:,:] = (img_data[:,i,:,:]/255 - mean_vec[i]) / stddev_vec[i]
     return norm_img_data
 ```


### PR DESCRIPTION
# Single Stage Detector

## Description
This model is a real-time neural network for object detection that detects 80 different classes.

## Model

|Model        |Download  |Checksum| Download (with sample test data)|ONNX version|Opset version|Accuracy |
|-------------|:--------------|:--------------|:--------------|:--------------|:--------------|:--------------|
|SSD       |[80.4 MB](https://onnxzoo.blob.core.windows.net/models/opset_10/ssd/ssd.onnx) | [MD5](https://onnxzoo.blob.core.windows.net/models/opset_10/ssd/ssd-md5.txt) | [78.5 MB](https://onnxzoo.blob.core.windows.net/models/opset_10/ssd/ssd.tar.gz) |1.4.1 |10 |mAP of 0.195 |



<hr>

## Inference

### Input to model
Image shape `(1x3x1200x1200)`

### Preprocessing steps
The images have to be loaded in to a range of [0, 1], resized to (1200, 1200) with bilinear interpolation and then normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225]. The transformation should preferrably happen at preprocessing.

The following code shows how to preprocess a NCHW tensor:

```python
import numpy as np
from PIL import Image

def preprocess(img_path):
    input_shape = (1, 3, 1200, 1200)
    img = Image.open(img_path)
    img = img.resize((1200, 1200), Image.BILINEAR)
    img_data = np.array(img)
    mean_vec = np.array([0.485, 0.456, 0.406])
    stddev_vec = np.array([0.229, 0.224, 0.225])
    norm_img_data = np.zeros(img_data.shape).astype('float32')
    for i in range(img_data.shape[1]):
        norm_img_data[:,i,:,:] = (img_data[:,i,:,:]/255 - mean_vec[i]) / stddev_vec[i]
    return norm_img_data
```

### Output of model
The model has 3 outputs.
boxes: `(1x'nbox'x4)`
labels: `(1x'nbox')`
scores: `(1x'nbox')`

## Dataset (Train and validation)
The SSD model was trained on 2017 COCO train data set - using mlperf/training/single_stage_detector repo , compute mAP on 2017 COCO val data set.
<hr>

## Validation accuracy
Metric is COCO box mAP (averaged over IoU of 0.5:0.95), computed over 2017 COCO val data.
mAP of 0.195
<hr>

## Publication/Attribution
Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott Reed, Cheng-Yang Fu, Alexander C. Berg. SSD: Single Shot MultiBox Detector. In the Proceedings of the European Conference on Computer Vision (ECCV), 2016.

Backbone is ResNet34 pretrained on ILSVRC 2012 (from torchvision). Modifications to the backbone networks: remove conv_5x residual blocks, change the first 3x3 convolution of the conv_4x block from stride 2 to stride1 (this increases the resolution of the feature map to which detector heads are attached), attach all 6 detector heads to the output of the last conv_4x residual block. Thus detections are attached to 38x38, 19x19, 10x10, 5x5, 3x3, and 1x1 feature maps. Convolutions in the detector layers are followed by batch normalization layers.
<hr>

## References
This model is converted from mlperf/inference [repository](https://github.com/mlperf/inference/tree/master/cloud/single_stage_detector) with modifications in [repository](https://github.com/BowenBao/inference/tree/master/cloud/single_stage_detector/pytorch).
<hr>

## License
Apache License 2.0
<hr>