### PR TITLE
Add yolov3 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Object detection models detect the presence of multiple objects in an image and 
 |<b>Faster-RCNN</b>|[Ren et al.](https://arxiv.org/abs/1506.01497)|[contribute](contribute.md)|
 |<b>Mask-RCNN</b>|[He et al.](https://arxiv.org/abs/1703.06870)|[contribute](contribute.md)|
 |<b>YOLO v2</b>|[Redmon et al.](https://arxiv.org/abs/1612.08242)|[contribute](contribute.md)|
-|<b>YOLO v3</b>|[Redmon et al.](https://pjreddie.com/media/files/papers/YOLOv3.pdf)|[contribute](contribute.md)|
+|<b>[YOLO v3](yolov3)</b>|[Redmon et al.](https://pjreddie.com/media/files/papers/YOLOv3.pdf)|Deep CNN model for Object Detection|
 |<b>[DUC](models/semantic_segmentation/DUC/)</b>|[Wang et al.](https://arxiv.org/abs/1702.08502)|Deep CNN based semantic segmentation model with >80% [mIOU](/models/semantic_segmentation/DUC/README.md/#metric) (mean Intersection Over Union), trained on urban street images|
 |<b>FCN</b>|[Long et al.](https://people.eecs.berkeley.edu/~jonlong/long_shelhamer_fcn.pdf)|[contribute](contribute.md)|
 <hr>

--- a/yolov3/README.md
+++ b/yolov3/README.md
@@ -1,0 +1,104 @@
+# YOLOv3
+
+## Description
+This model is a real-time neural network for object detection that detects 80 different classes.
+
+## Model
+
+|Model        |Download  |Checksum|ONNX version|Opset version|Accuracy |
+|-------------|:--------------|:--------------|:--------------|:--------------|:--------------|
+|YOLOv3       |[237 MB](https://onnxzoo.blob.core.windows.net/models/opset_10/yolov3/yolov3.onnx) | [MD5](https://onnxzoo.blob.core.windows.net/models/opset_10/yolov3/yolov3-md5.txt) |1.4.1 |10 |mAP of 0.553 |
+
+
+
+<hr>
+
+## Inference
+
+### Input to model
+Image shape `(1x3x416x416)`
+
+### Preprocessing steps
+The images have to be loaded in to a range of [0, 1]. The transformation should preferrably happen at preprocessing.
+
+The following code shows how to preprocess a NCHW tensor:
+
+```python
+import numpy as np
+from PIL import Image
+
+# this function is from yolo3.utils.letterbox_image
+def letterbox_image(image, size):
+    '''resize image with unchanged aspect ratio using padding'''
+    iw, ih = image.size
+    w, h = size
+    scale = min(w/iw, h/ih)
+    nw = int(iw*scale)
+    nh = int(ih*scale)
+
+    image = image.resize((nw,nh), Image.BICUBIC)
+    new_image = Image.new('RGB', size, (128,128,128))
+    new_image.paste(image, ((w-nw)//2, (h-nh)//2))
+    return new_image
+
+# img = Image.open(img_path)
+def preprocess(img):
+    model_image_size = (416, 416)
+    boxed_image = letterbox_image(img, tuple(reversed(model_image_size)))
+    image_data = np.array(boxed_image, dtype='float32')
+    image_data /= 255.
+    image_data = np.transpose(image_data, [2, 0, 1])
+    image_data = np.expand_dims(image_data, 0)
+    return image_data
+```
+
+### Output of model
+The model has 3 outputs.
+boxes: `(1x'n_candidates'x4)`, the coordinates of all anchor boxes,
+scores: `(1x80x'n_candidates')`, the scores of all anchor boxes per class,
+indices: `('nbox'x3)`, selected indices from the boxes tensor. The selected index format is (batch_index, class_index, box_index).
+
+Here is the python API to run onnx model:
+```
+import onnxruntime
+sess = onnxruntime.InferenceSession('yolov3.onnx')
+feed_f = dict(zip(['input_1:01', 'image_shape:01'],
+             (image_data, np.array([image.size[1], image.size[0]], dtype=np.int32).reshape(1, 2))))
+all_boxes, all_scores, indices = sess.run(None, input_feed=feed_f)
+```
+
+## Postprocessing steps
+Post processing and meaning of output
+```
+out_boxes, out_scores, out_classes = [], [], []
+for idx_ in indices:
+    out_classes.append(idx_[1])
+    out_scores.append(all_scores[tuple(idx_)])
+    idx_1 = (idx_[0], idx_[2])
+    out_boxes.append(all_boxes[idx_1])
+```
+out_boxes, out_scores, out_classes are list of resulting boxes, scores, and classes.
+<hr>
+
+## Dataset (Train and validation)
+We use pretrained weights from pjreddie.com [here](https://pjreddie.com/media/files/yolov3.weights).
+<hr>
+
+## Validation accuracy
+Metric is COCO box mAP (averaged over IoU of 0.5:0.95), computed over 2017 COCO val data.
+mAP of 0.553.
+<hr>
+
+## Publication/Attribution
+Joseph Redmon, Ali Farhadi. YOLOv3: An Incremental Improvement, [paper](https://pjreddie.com/media/files/papers/YOLOv3.pdf)
+
+<hr>
+
+## References
+This model is converted from a keras model [repository](https://github.com/qqwweee/keras-yolo3) using
+keras2onnx convertor [repository](https://github.com/onnx/keras-onnx).
+<hr>
+
+## License
+Apache License 2.0
+<hr>


### PR DESCRIPTION
# YOLOv3

## Description
This model is a neural network for real-time object detection that detects 80 different classes. It is very fast and accurate.

## Model

|Model        |Download  |Checksum|Download (with sample test data)|ONNX version|Opset version|Accuracy |
|-------------|:--------------|:--------------|:--------------|:--------------|:--------------|:--------------|
|YOLOv3       |[237 MB](https://onnxzoo.blob.core.windows.net/models/opset_10/yolov3/yolov3.onnx) | [MD5](https://onnxzoo.blob.core.windows.net/models/opset_10/yolov3/yolov3-md5.txt) |[222 MB](https://onnxzoo.blob.core.windows.net/models/opset_10/yolov3/yolov3.tar.gz)|1.5 |10 |mAP of 0.553 |



<hr>

## Inference

### Input to model
Resized image `(1x3x416x416)`
Original image size `(1x2)` which is `[image.size[1], image.size[0]]` 

### Preprocessing steps
The images have to be loaded in to a range of [0, 1]. The transformation should preferrably happen at preprocessing.

The following code shows how to preprocess a NCHW tensor:

```python
import numpy as np
from PIL import Image

# this function is from yolo3.utils.letterbox_image
def letterbox_image(image, size):
    '''resize image with unchanged aspect ratio using padding'''
    iw, ih = image.size
    w, h = size
    scale = min(w/iw, h/ih)
    nw = int(iw*scale)
    nh = int(ih*scale)

    image = image.resize((nw,nh), Image.BICUBIC)
    new_image = Image.new('RGB', size, (128,128,128))
    new_image.paste(image, ((w-nw)//2, (h-nh)//2))
    return new_image

def preprocess(img):
    model_image_size = (416, 416)
    boxed_image = letterbox_image(img, tuple(reversed(model_image_size)))
    image_data = np.array(boxed_image, dtype='float32')
    image_data /= 255.
    image_data = np.transpose(image_data, [2, 0, 1])
    image_data = np.expand_dims(image_data, 0)
    return image_data

image = Image.open(img_path)
# input
image_data = preprocess(image)
image_size = np.array([image.size[1], image.size[0]], dtype=np.int32).reshape(1, 2)
```

### Output of model
The model has 3 outputs.
boxes: `(1x'n_candidates'x4)`, the coordinates of all anchor boxes,
scores: `(1x80x'n_candidates')`, the scores of all anchor boxes per class,
indices: `('nbox'x3)`, selected indices from the boxes tensor. The selected index format is (batch_index, class_index, box_index). The class list is [here](https://github.com/qqwweee/keras-yolo3/blob/master/model_data/coco_classes.txt)

## Postprocessing steps
Post processing and meaning of output
```
out_boxes, out_scores, out_classes = [], [], []
for idx_ in indices:
    out_classes.append(idx_[1])
    out_scores.append(scores[tuple(idx_)])
    idx_1 = (idx_[0], idx_[2])
    out_boxes.append(boxes[idx_1])
```
out_boxes, out_scores, out_classes are list of resulting boxes, scores, and classes.
<hr>

## Dataset (Train and validation)
We use pretrained weights from pjreddie.com [here](https://pjreddie.com/media/files/yolov3.weights).
<hr>

## Validation accuracy
Metric is COCO box mAP (averaged over IoU of 0.5:0.95), computed over 2017 COCO val data.
mAP of 0.553 based on original Yolov3 model [here](https://pjreddie.com/darknet/yolo/)
<hr>

## Publication/Attribution
Joseph Redmon, Ali Farhadi. YOLOv3: An Incremental Improvement, [paper](https://pjreddie.com/media/files/papers/YOLOv3.pdf)

<hr>

## References
This model is converted from a keras model [repository](https://github.com/qqwweee/keras-yolo3) using keras2onnx convertor [repository](https://github.com/onnx/keras-onnx).
<hr>

## License
MIT License
<hr>