### PR TITLE
Git LFS for CV models: CaffeNet, DenseNet, GoogleNet, Inception (x2)

### DIFF
--- a/vision/classification/caffenet/README.md
+++ b/vision/classification/caffenet/README.md
@@ -1,12 +1,12 @@
 # CaffeNet
-Download:
-- release 1.1: https://s3.amazonaws.com/download.onnx/models/opset_3/bvlc_reference_caffenet.tar.gz
-- release 1.1.2: https://s3.amazonaws.com/download.onnx/models/opset_6/bvlc_reference_caffenet.tar.gz
-- release 1.2: https://s3.amazonaws.com/download.onnx/models/opset_7/bvlc_reference_caffenet.tar.gz
-- release 1.3: https://s3.amazonaws.com/download.onnx/models/opset_8/bvlc_reference_caffenet.tar.gz
-- master: https://s3.amazonaws.com/download.onnx/models/opset_9/bvlc_reference_caffenet.tar.gz
 
-Model size: 244 MB
+|Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+|CaffeNet| [238 MB](model/caffenet-3.onnx)  |  [244 MB](model/caffenet-3.tar.gz) |  1.1 | 3|
+|CaffeNet| [238 MB](model/caffenet-6.onnx)  |  [244 MB](model/caffenet-6.tar.gz) |  1.1.2 | 6|
+|CaffeNet| [238 MB](model/caffenet-7.onnx)  |  [244 MB](model/caffenet-7.tar.gz) |  1.2 | 7|
+|CaffeNet| [238 MB](model/caffenet-8.onnx)  |  [244 MB](model/caffenet-8.tar.gz) |  1.3 | 8|
+|CaffeNet| [238 MB](model/caffenet-9.onnx)  |  [244 MB](model/caffenet-9.tar.gz) |  1.4 | 9|
 
 ## Description
 CaffeNet a variant of AlexNet.

--- a/vision/classification/caffenet/model/caffenet-3.onnx
+++ b/vision/classification/caffenet/model/caffenet-3.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15e568474e1c2af94cc34b812628707fee0130f3a3c8b3329cbc5e4ba9248682
+size 243863639

--- a/vision/classification/caffenet/model/caffenet-3.tar.gz
+++ b/vision/classification/caffenet/model/caffenet-3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf91013f28e461722dc47acfc1ebd8464c8320d4276902204a1d810a6dd2ff2a
+size 229550795

--- a/vision/classification/caffenet/model/caffenet-6.onnx
+++ b/vision/classification/caffenet/model/caffenet-6.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e362cbd353e7a0432d46ec608bfc38646aa8d70207ddb92788008816603ce835
+size 243863525

--- a/vision/classification/caffenet/model/caffenet-6.tar.gz
+++ b/vision/classification/caffenet/model/caffenet-6.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6a210e64d1964f8132cbe9ea46d4ab8e7fcf2634ce4285b701deb3fe3e7dd1c
+size 229550734

--- a/vision/classification/caffenet/model/caffenet-7.onnx
+++ b/vision/classification/caffenet/model/caffenet-7.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a249fe5683aa6b517dfb198e4b3bd40a1b7611d4995fde0b0b9ced5f4143bc5c
+size 243863553

--- a/vision/classification/caffenet/model/caffenet-7.tar.gz
+++ b/vision/classification/caffenet/model/caffenet-7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0287e08e40dcaf179e450da00da75b467235da6ded9f8bdf27b37ef15c340e1
+size 229551315

--- a/vision/classification/caffenet/model/caffenet-8.onnx
+++ b/vision/classification/caffenet/model/caffenet-8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82f8997778cd9c5ef9673fc86e340f86e3b29650886b923e5e1aa478d5f83f92
+size 243863553

--- a/vision/classification/caffenet/model/caffenet-8.tar.gz
+++ b/vision/classification/caffenet/model/caffenet-8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69292692098ccecb7df067c577165de0c2c1885cca821045648f93f6964af0ed
+size 229551319

--- a/vision/classification/caffenet/model/caffenet-9.onnx
+++ b/vision/classification/caffenet/model/caffenet-9.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:802138332cf3e423c82a9a80c76e4f9227dd4effb3aba55413601fa4345cfd36
+size 243863553

--- a/vision/classification/caffenet/model/caffenet-9.tar.gz
+++ b/vision/classification/caffenet/model/caffenet-9.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae8ac99c5627bc69e63db078a4fb46b547e1a589010eb0bd97dd1501646dea14
+size 229551368

--- a/vision/classification/densenet-121/README.md
+++ b/vision/classification/densenet-121/README.md
@@ -1,13 +1,12 @@
 # DenseNet-121
 
-Download:
-- release 1.1: https://s3.amazonaws.com/download.onnx/models/opset_3/densenet121.tar.gz
-- release 1.1.2: https://s3.amazonaws.com/download.onnx/models/opset_6/densenet121.tar.gz
-- release 1.2: https://s3.amazonaws.com/download.onnx/models/opset_7/densenet121.tar.gz
-- release 1.3: https://s3.amazonaws.com/download.onnx/models/opset_8/densenet121.tar.gz
-- master: https://s3.amazonaws.com/download.onnx/models/opset_9/densenet121.tar.gz
-
-Model size: 33 MB
+|Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+|DenseNet-121| [32 MB](model/densenet-3.onnx)  |  [33 MB](model/densenet-3.tar.gz) |  1.1 | 3|
+|DenseNet-121| [32 MB](model/densenet-6.onnx)  |  [33 MB](model/densenet-6.tar.gz) |  1.1.2 | 6|
+|DenseNet-121| [32 MB](model/densenet-7.onnx)  |  [33 MB](model/densenet-7.tar.gz) |  1.2 | 7|
+|DenseNet-121| [32 MB](model/densenet-8.onnx)  |  [33 MB](model/densenet-8.tar.gz) |  1.3 | 8|
+|DenseNet-121| [32 MB](model/densenet-9.onnx)  |  [33 MB](model/densenet-9.tar.gz) |  1.4 | 9|
 
 ## Description
 DenseNet-121 is a convolutional neural network for classification.

--- a/vision/classification/densenet-121/model/densenet-3.onnx
+++ b/vision/classification/densenet-121/model/densenet-3.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7749c7b6c419cf2b8c6b8a979c86bb3d322976578682662b852cae36e2b79b41
+size 32718955

--- a/vision/classification/densenet-121/model/densenet-3.tar.gz
+++ b/vision/classification/densenet-121/model/densenet-3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70586d81f49ad3bbe733270a1a58b5235794d51da3f9302cbc1e634accb6113d
+size 33658961

--- a/vision/classification/densenet-121/model/densenet-6.onnx
+++ b/vision/classification/densenet-121/model/densenet-6.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:875fb597a9f0f79cca8a9db610a355920b13959fbe7dc35b759dd35f4d25e291
+size 32719461

--- a/vision/classification/densenet-121/model/densenet-6.tar.gz
+++ b/vision/classification/densenet-121/model/densenet-6.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68377f0df580eb3a269d6afd5e3837ea75de23a28ae11e88c4714213b1df44d7
+size 33660618

--- a/vision/classification/densenet-121/model/densenet-7.onnx
+++ b/vision/classification/densenet-121/model/densenet-7.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79c3bc0974696a2ea9efd2f7bca19fdd630834bd0086f1b4a1c3db3dce3b2a51
+size 32719461

--- a/vision/classification/densenet-121/model/densenet-7.tar.gz
+++ b/vision/classification/densenet-121/model/densenet-7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51962687b5fd5ac636fb8b682a463d607f5c6713c21514fcd7d89a02c81a3d11
+size 33660614

--- a/vision/classification/densenet-121/model/densenet-8.onnx
+++ b/vision/classification/densenet-121/model/densenet-8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c57fd1e5864ddc808a84567d0d3a1ea6b5e4d1afbec17372723503be7a030e3a
+size 32719461

--- a/vision/classification/densenet-121/model/densenet-8.tar.gz
+++ b/vision/classification/densenet-121/model/densenet-8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c44501ca60c207076bd400f2dbedcfc19b92e98a4fffe929a4e007acccb207c0
+size 33660609

--- a/vision/classification/densenet-121/model/densenet-9.onnx
+++ b/vision/classification/densenet-121/model/densenet-9.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:875fb597a9f0f79cca8a9db610a355920b13959fbe7dc35b759dd35f4d25e291
+size 32719461

--- a/vision/classification/densenet-121/model/densenet-9.tar.gz
+++ b/vision/classification/densenet-121/model/densenet-9.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68377f0df580eb3a269d6afd5e3837ea75de23a28ae11e88c4714213b1df44d7
+size 33660618

--- a/vision/classification/inception_and_googlenet/googlenet/README.md
+++ b/vision/classification/inception_and_googlenet/googlenet/README.md
@@ -2,11 +2,11 @@
 
 |Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-|GoogleNet-121| [28 MB](model/googlenet-3.onnx)  |  [31 MB](model/googlenet-3.tar.gz) |  1.1 | 3|
-|GoogleNet-121| [28 MB](model/googlenet-6.onnx)  |  [31 MB](model/googlenet-6.tar.gz) |  1.1.2 | 6|
-|GoogleNet-121| [28 MB](model/googlenet-7.onnx)  |  [31 MB](model/googlenet-7.tar.gz) |  1.2 | 7|
-|GoogleNet-121| [28 MB](model/googlenet-8.onnx)  |  [31 MB](model/googlenet-8.tar.gz) |  1.3 | 8|
-|GoogleNet-121| [28 MB](model/googlenet-9.onnx)  |  [31 MB](model/googlenet-9.tar.gz) |  1.4 | 9|
+|GoogleNet| [28 MB](model/googlenet-3.onnx)  |  [31 MB](model/googlenet-3.tar.gz) |  1.1 | 3|
+|GoogleNet| [28 MB](model/googlenet-6.onnx)  |  [31 MB](model/googlenet-6.tar.gz) |  1.1.2 | 6|
+|GoogleNet| [28 MB](model/googlenet-7.onnx)  |  [31 MB](model/googlenet-7.tar.gz) |  1.2 | 7|
+|GoogleNet| [28 MB](model/googlenet-8.onnx)  |  [31 MB](model/googlenet-8.tar.gz) |  1.3 | 8|
+|GoogleNet| [28 MB](model/googlenet-9.onnx)  |  [31 MB](model/googlenet-9.tar.gz) |  1.4 | 9|
 
 ## Description
 GoogLeNet is the name of a convolutional neural network for classification,

--- a/vision/classification/inception_and_googlenet/googlenet/README.md
+++ b/vision/classification/inception_and_googlenet/googlenet/README.md
@@ -1,12 +1,12 @@
 # GoogleNet
-Download:
-- release 1.1: https://s3.amazonaws.com/download.onnx/models/opset_3/bvlc_googlenet.tar.gz
-- release 1.1.2: https://s3.amazonaws.com/download.onnx/models/opset_6/bvlc_googlenet.tar.gz
-- release 1.2: https://s3.amazonaws.com/download.onnx/models/opset_7/bvlc_googlenet.tar.gz
-- release 1.3: https://s3.amazonaws.com/download.onnx/models/opset_8/bvlc_googlenet.tar.gz
-- master: https://s3.amazonaws.com/download.onnx/models/opset_9/bvlc_googlenet.tar.gz
 
-Model size: 28 MB
+|Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+|GoogleNet-121| [32 MB](model/googlenet-3.onnx)  |  [28 MB](model/googlenet-3.tar.gz) |  1.1 | 3|
+|GoogleNet-121| [32 MB](model/googlenet-6.onnx)  |  [28 MB](model/googlenet-6.tar.gz) |  1.1.2 | 6|
+|GoogleNet-121| [32 MB](model/googlenet-7.onnx)  |  [28 MB](model/googlenet-7.tar.gz) |  1.2 | 7|
+|GoogleNet-121| [32 MB](model/googlenet-8.onnx)  |  [28 MB](model/googlenet-8.tar.gz) |  1.3 | 8|
+|GoogleNet-121| [32 MB](model/googlenet-9.onnx)  |  [28 MB](model/googlenet-9.tar.gz) |  1.4 | 9|
 
 ## Description
 GoogLeNet is the name of a convolutional neural network for classification,

--- a/vision/classification/inception_and_googlenet/googlenet/README.md
+++ b/vision/classification/inception_and_googlenet/googlenet/README.md
@@ -2,11 +2,11 @@
 
 |Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-|GoogleNet-121| [32 MB](model/googlenet-3.onnx)  |  [28 MB](model/googlenet-3.tar.gz) |  1.1 | 3|
-|GoogleNet-121| [32 MB](model/googlenet-6.onnx)  |  [28 MB](model/googlenet-6.tar.gz) |  1.1.2 | 6|
-|GoogleNet-121| [32 MB](model/googlenet-7.onnx)  |  [28 MB](model/googlenet-7.tar.gz) |  1.2 | 7|
-|GoogleNet-121| [32 MB](model/googlenet-8.onnx)  |  [28 MB](model/googlenet-8.tar.gz) |  1.3 | 8|
-|GoogleNet-121| [32 MB](model/googlenet-9.onnx)  |  [28 MB](model/googlenet-9.tar.gz) |  1.4 | 9|
+|GoogleNet-121| [28 MB](model/googlenet-3.onnx)  |  [31 MB](model/googlenet-3.tar.gz) |  1.1 | 3|
+|GoogleNet-121| [28 MB](model/googlenet-6.onnx)  |  [31 MB](model/googlenet-6.tar.gz) |  1.1.2 | 6|
+|GoogleNet-121| [28 MB](model/googlenet-7.onnx)  |  [31 MB](model/googlenet-7.tar.gz) |  1.2 | 7|
+|GoogleNet-121| [28 MB](model/googlenet-8.onnx)  |  [31 MB](model/googlenet-8.tar.gz) |  1.3 | 8|
+|GoogleNet-121| [28 MB](model/googlenet-9.onnx)  |  [31 MB](model/googlenet-9.tar.gz) |  1.4 | 9|
 
 ## Description
 GoogLeNet is the name of a convolutional neural network for classification,

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-3.onnx
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-3.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5725ccfd90845735ce5897faf7843c3f9b13acda3c4f3bff82cb21c9337c9de8
+size 28020232

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-3.tar.gz
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e4045f1cfec9936588a1f0352ce32b4764cc844013403f8116854c5bc4ff184
+size 30906583

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-6.onnx
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-6.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd979d99d10d9acf84c5a67252bcae4992bf4e1afdab046cb0ea370e6f01ee38
+size 28020232

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-6.tar.gz
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-6.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8e2cf0321f97283d3e8664e0e35fffc5aee52c4c078d0655b29e4972867bcac
+size 30906642

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-7.onnx
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-7.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5725ccfd90845735ce5897faf7843c3f9b13acda3c4f3bff82cb21c9337c9de8
+size 28020232

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-7.tar.gz
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e4045f1cfec9936588a1f0352ce32b4764cc844013403f8116854c5bc4ff184
+size 30906583

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d343d459199fbcc8cd43d45264180e3e1ef91d4908f3541b5b308995206362c
+size 28020232

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.tar.gz
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24f8576ba8ea7e0589af6dabfc236e564dd01d94823a2fcb6a762ad3bf736c37
+size 30906601

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd979d99d10d9acf84c5a67252bcae4992bf4e1afdab046cb0ea370e6f01ee38
+size 28020232

--- a/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.tar.gz
+++ b/vision/classification/inception_and_googlenet/googlenet/model/googlenet-9.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8e2cf0321f97283d3e8664e0e35fffc5aee52c4c078d0655b29e4972867bcac
+size 30906642

--- a/vision/classification/inception_and_googlenet/inception_v1/README.md
+++ b/vision/classification/inception_and_googlenet/inception_v1/README.md
@@ -1,13 +1,12 @@
 # Inception v1
 
-Download:
-- release 1.1: https://s3.amazonaws.com/download.onnx/models/opset_3/inception_v1.tar.gz
-- release 1.1.2: https://s3.amazonaws.com/download.onnx/models/opset_6/inception_v1.tar.gz
-- release 1.2: https://s3.amazonaws.com/download.onnx/models/opset_7/inception_v1.tar.gz
-- release 1.3: https://s3.amazonaws.com/download.onnx/models/opset_8/inception_v1.tar.gz
-- master: https://s3.amazonaws.com/download.onnx/models/opset_9/inception_v1.tar.gz
-
-Model size: 28 MB
+|Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+|Inception-1| [28 MB](model/inception-v1-3.onnx)  |  [31 MB](model/inception-v1-3.tar.gz) |  1.1 | 3|
+|Inception-1| [28 MB](model/inception-v1-6.onnx)  |  [31 MB](model/inception-v1-6.tar.gz) |  1.1.2 | 6|
+|Inception-1| [28 MB](model/inception-v1-7.onnx)  |  [31 MB](model/inception-v1-7.tar.gz) |  1.2 | 7|
+|Inception-1| [28 MB](model/inception-v1-8.onnx)  |  [31 MB](model/inception-v1-8.tar.gz) |  1.3 | 8|
+|Inception-1| [28 MB](model/inception-v1-9.onnx)  |  [31 MB](model/inception-v1-9.tar.gz) |  1.4 | 9|
 
 ## Description
 Inception v1 is a reproduction of GoogLeNet.

--- a/vision/classification/inception_and_googlenet/inception_v1/README.md
+++ b/vision/classification/inception_and_googlenet/inception_v1/README.md
@@ -2,11 +2,11 @@
 
 |Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-|Inception-1| [28 MB](model/inception-v1-3.onnx)  |  [31 MB](model/inception-v1-3.tar.gz) |  1.1 | 3|
-|Inception-1| [28 MB](model/inception-v1-6.onnx)  |  [31 MB](model/inception-v1-6.tar.gz) |  1.1.2 | 6|
-|Inception-1| [28 MB](model/inception-v1-7.onnx)  |  [31 MB](model/inception-v1-7.tar.gz) |  1.2 | 7|
-|Inception-1| [28 MB](model/inception-v1-8.onnx)  |  [31 MB](model/inception-v1-8.tar.gz) |  1.3 | 8|
-|Inception-1| [28 MB](model/inception-v1-9.onnx)  |  [31 MB](model/inception-v1-9.tar.gz) |  1.4 | 9|
+|Inception-1| [28 MB](model/inception-v1-3.onnx)  |  [29 MB](model/inception-v1-3.tar.gz) |  1.1 | 3|
+|Inception-1| [28 MB](model/inception-v1-6.onnx)  |  [29 MB](model/inception-v1-6.tar.gz) |  1.1.2 | 6|
+|Inception-1| [28 MB](model/inception-v1-7.onnx)  |  [29 MB](model/inception-v1-7.tar.gz) |  1.2 | 7|
+|Inception-1| [28 MB](model/inception-v1-8.onnx)  |  [29 MB](model/inception-v1-8.tar.gz) |  1.3 | 8|
+|Inception-1| [28 MB](model/inception-v1-9.onnx)  |  [29 MB](model/inception-v1-9.tar.gz) |  1.4 | 9|
 
 ## Description
 Inception v1 is a reproduction of GoogLeNet.

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-3.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-3.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e6a6091a76dcc34b7afd68cec9355687278844b92fb0364b608e5c6f33067e8
+size 28020217

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-3.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18dd953ae8f2056ac0a1fd56302ef2a5d56b35ccee44fddc7bbdcbcfe9a5adf1
+size 29324028

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-6.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-6.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e7c4e026430fc055cb040dfe7f7978556b3af13cd618a7866841c00dd6d178f
+size 28020390

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-6.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-6.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caf55082c6605ff17e0074e7af862f774b6efb00557236676e7112f6f54cec61
+size 29324092

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-7.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-7.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaa5c289961ef2134290ddd42852d818d1d40fce18ffbc876bc446483343af9c
+size 28020356

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-7.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bae43d53cc836bcd20cc5eacdd12c2d24d34c17e960a3342d7501489d5d9157
+size 29323411

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-8.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec956d393dd467b6d9e0b17b8c8227c534b936bfbcdc82343a3a7238375775f0
+size 28020356

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-8.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2104acf056bf9c7ce2407fd1e886eb9bec78413639c7c14f1c15a096305932b7
+size 29323364

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8b7bb4040377b83089eef98800a15303325ed75ced468a8972a87e0bc23692e
+size 28020356

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2242cbd72b324f384e767634bc9acf4db240aea3ae15d6a1817ee81256d016ce
+size 29323358

--- a/vision/classification/inception_and_googlenet/inception_v2/README.md
+++ b/vision/classification/inception_and_googlenet/inception_v2/README.md
@@ -2,11 +2,11 @@
 
 |Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-|Inception-2| [45 MB](model/inception-v2-3.onnx)  |  [31 MB](model/inception-v2-3.tar.gz) |  1.1 | 3|
-|Inception-2| [45 MB](model/inception-v2-6.onnx)  |  [31 MB](model/inception-v2-6.tar.gz) |  1.1.2 | 6|
-|Inception-2| [45 MB](model/inception-v2-7.onnx)  |  [31 MB](model/inception-v2-7.tar.gz) |  1.2 | 7|
-|Inception-2| [45 MB](model/inception-v2-8.onnx)  |  [31 MB](model/inception-v2-8.tar.gz) |  1.3 | 8|
-|Inception-2| [45 MB](model/inception-v2-9.onnx)  |  [31 MB](model/inception-v2-9.tar.gz) |  1.4 | 9|
+|Inception-2| [44 MB](model/inception-v2-3.onnx)  |  [44 MB](model/inception-v2-3.tar.gz) |  1.1 | 3|
+|Inception-2| [44 MB](model/inception-v2-6.onnx)  |  [44 MB](model/inception-v2-6.tar.gz) |  1.1.2 | 6|
+|Inception-2| [44 MB](model/inception-v2-7.onnx)  |  [44 MB](model/inception-v2-7.tar.gz) |  1.2 | 7|
+|Inception-2| [44 MB](model/inception-v2-8.onnx)  |  [44 MB](model/inception-v2-8.tar.gz) |  1.3 | 8|
+|Inception-2| [44 MB](model/inception-v2-9.onnx)  |  [44 MB](model/inception-v2-9.tar.gz) |  1.4 | 9|
 
 ## Description
 Inception v2 is a deep convolutional networks for classification.

--- a/vision/classification/inception_and_googlenet/inception_v2/README.md
+++ b/vision/classification/inception_and_googlenet/inception_v2/README.md
@@ -1,13 +1,12 @@
 # Inception v2
 
-Download:
-- release 1.1: https://s3.amazonaws.com/download.onnx/models/opset_3/inception_v2.tar.gz
-- release 1.1.2: https://s3.amazonaws.com/download.onnx/models/opset_6/inception_v2.tar.gz
-- release 1.2: https://s3.amazonaws.com/download.onnx/models/opset_7/inception_v2.tar.gz
-- release 1.3: https://s3.amazonaws.com/download.onnx/models/opset_8/inception_v2.tar.gz
-- master: https://s3.amazonaws.com/download.onnx/models/opset_9/inception_v2.tar.gz
-
-Model size: 45 MB
+|Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+|Inception-2| [45 MB](model/inception-v2-3.onnx)  |  [31 MB](model/inception-v2-3.tar.gz) |  1.1 | 3|
+|Inception-2| [45 MB](model/inception-v2-6.onnx)  |  [31 MB](model/inception-v2-6.tar.gz) |  1.1.2 | 6|
+|Inception-2| [45 MB](model/inception-v2-7.onnx)  |  [31 MB](model/inception-v2-7.tar.gz) |  1.2 | 7|
+|Inception-2| [45 MB](model/inception-v2-8.onnx)  |  [31 MB](model/inception-v2-8.tar.gz) |  1.3 | 8|
+|Inception-2| [45 MB](model/inception-v2-9.onnx)  |  [31 MB](model/inception-v2-9.tar.gz) |  1.4 | 9|
 
 ## Description
 Inception v2 is a deep convolutional networks for classification.

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-3.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-3.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bb3ba787e84667bc1169034c36a1f1c1cddfbd19d5e48c9c51306a087973bc8
+size 45042595

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-3.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ea826b395c559ed2cc148823ea77f793e591c5eff5a718d98733793b680dbc
+size 45015362

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-6.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-6.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53626ce95a96756469d23b8dd917f8b5a6015c628369d219bdbf17bb5d0178f5
+size 45040501

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-6.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-6.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a29498bbf22d78dc428f0b6a0ecdc350475896ccb653c0b8d544c14000509b0a
+size 45015338

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-7.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-7.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1ada57696a4d2c23984b8584cd8df40243301f7344475a8653118c0d5da57a5
+size 45042799

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-7.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c23f2596676c27640d668115588c25771a5645966e5f00e858295e3cd9fbfd58
+size 45015328

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-8.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:878e9c04172215cb7a1ce225dfecfe2ed098abde5cb1067dc644a3629ec6dcf1
+size 45042799

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-8.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2e7863a96ace0783328586e75fd59ccaa7e7de7bd72be6d030cc206e312b690
+size 45015310

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ed4aa93f817fd0d1cc19bda045ebd70f18d0887a5f51e66ecd0ed8fd5a65c2
+size 45042799

--- a/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4b06f72212011ed60e3515242ea7f7695ff59e0735633953573ad053b57abfe
+size 45015320


### PR DESCRIPTION
moving to git LFS for 5 classification models

#271