### PR TITLE
TinyYoloV2 - Git LFS migration

### DIFF
--- a/vision/object_detection_segmentation/tiny-yolov2/README.md
+++ b/vision/object_detection_segmentation/tiny-yolov2/README.md
@@ -1,14 +1,16 @@
 # Tiny YOLOv2
 
 ## Description
-This model is a real-time neural network for object detection that detects 20 different classes. It is made up of 9 convolutional layers and 6 max-pooling layers and is a smaller version of the more complex full [YOLOv2](https://pjreddie.com/darknet/yolov2/) network. 
+This model is a real-time neural network for object detection that detects 20 different classes. It is made up of 9 convolutional layers and 6 max-pooling layers and is a smaller version of the more complex full [YOLOv2](https://pjreddie.com/darknet/yolov2/) network.
+
+CoreML TinyYoloV2 ==> ONNX TinyYoloV2
 
 ## Model
-|Model|Checksum|Download (with sample test data)| ONNX version |Opset version|
+|Model|Download|Download (with sample test data)| ONNX version |Opset version|
 |-----|:-------|:-------------------------------|:-------------|:------------|
-|Tiny YOLOv2|[MD5](https://onnxzoo.blob.core.windows.net/models/opset_1/tiny_yolov2/tiny_yolov2-md5.txt)|[58 MB](https://onnxzoo.blob.core.windows.net/models/opset_1/tiny_yolov2/tiny_yolov2.tar.gz) |1.0  |1 |
-|     |[MD5](https://onnxzoo.blob.core.windows.net/models/opset_7/tiny_yolov2/tiny_yolov2-md5.txt)|[58 MB](https://onnxzoo.blob.core.windows.net/models/opset_7/tiny_yolov2/tiny_yolov2.tar.gz) |1.2  |7 |
-|     |[MD5](https://onnxzoo.blob.core.windows.net/models/opset_8/tiny_yolov2/tiny_yolov2-md5.txt)|[58 MB](https://onnxzoo.blob.core.windows.net/models/opset_8/tiny_yolov2/tiny_yolov2.tar.gz) |1.3  |8 |
+|Tiny YOLOv2|[62 MB](model/tinyyolov2-1.onnx)|[59 MB](model/tinyyolov2-1.tar.gz) |1.0  |1 |
+|     |[62 MB](model/tinyyolov2-7.onnx)|[59 MB](model/tinyyolov2-7.tar.gz) |1.2  |7 |
+|     |[62 MB](model/tinyyolov2-8.onnx)|[59 MB](model/tinyyolov2-8.tar.gz) |1.3  |8 |
 
 ### Paper
 "YOLO9000: Better, Faster, Stronger" [arXiv:1612.08242](https://arxiv.org/pdf/1612.08242.pdf)
@@ -28,7 +30,7 @@ shape `(1x125x13x13)`
 ### Postprocessing
 The output is a `(125x13x13)` tensor where 13x13 is the number of grid cells that the image gets divided into. Each grid cell corresponds to 125 channels, made up of the 5 bounding boxes predicted by the grid cell and the 25 data elements that describe each bounding box (`5x25=125`). For more information on how to derive the final bounding boxes and their corresponding confidence scores, refer to this [post](http://machinethink.net/blog/object-detection-with-yolo/).
 ### Sample test data
-Sets of sample input and output files are provided in 
+Sets of sample input and output files are provided in
 * serialized protobuf TensorProtos (`.pb`), which are stored in the folders `test_data_set_*/`.
 
 ## License

--- a/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-1.onnx
+++ b/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-1.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3051a1dc1fc43acf10d2506d50fc679da6b91aaa25df7d98de27b52673586e57
+size 63479189

--- a/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-1.tar.gz
+++ b/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7cbdabdac0e557429f011a31fb91c0504f9698b9c7af2f7e5e4d0c7570b2470
+size 60776410

--- a/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-7.onnx
+++ b/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-7.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87befe217358b6beda0b496536b17216ebddef8f70e8d86fe34ed089bb577289
+size 63480982

--- a/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-7.tar.gz
+++ b/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bcdc5e4884784c13bdc131f418040129885960e98134fc1bac7a97373418023
+size 60875841

--- a/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8.onnx
+++ b/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:583fb7fdc948435ceac9fa82efc7708701efe8382a859a3dd46526b155f5f2ae
+size 63480982

--- a/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8.tar.gz
+++ b/vision/object_detection_segmentation/tiny-yolov2/model/tinyyolov2-8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d64e5b246b6ffa5ba9defcf72e726ac2dcfc97a8e1a79b43bf184f3caad7ea5
+size 60875831


### PR DESCRIPTION
#271 
TinyYoloV2 migration to Git LFS, deprecating checksums.