### PR TITLE
Fixing Squeezenet 1.1 opset 7 model

### DIFF
--- a/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
+++ b/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9456373b67f04e4a9cb0bb9be984f0db2d0ad141582d84d4b4ad9e84f7ec7785
-size 9165684
+oid sha256:1eeff551a67ae8d565ca33b572fc4b66e3ef357b0eb2863bb9ff47a918cc4088
+size 4956208


### PR DESCRIPTION
Squeezenet 1.1 upload has a protobuf parsing error. Updated with a working version based on the original submitter's link. Likely was a git LFS upload error.