### PR TITLE
Adding GPT-2-LH-Model model

### DIFF
--- a/text/machine_comprehension/gpt-2/README.md
+++ b/text/machine_comprehension/gpt-2/README.md
@@ -111,7 +111,7 @@ This model is converted directly from [huggingface/transformers](https://github.
 <hr>
 
 ## Contributors
-Negin Raoof
+Negin Raoof  
 Joddiy Zhang
 <hr>
 

--- a/text/machine_comprehension/gpt-2/README.md
+++ b/text/machine_comprehension/gpt-2/README.md
@@ -11,6 +11,7 @@ Transformer-based language model for text generation.
  |Model        |Download  | Download (with sample test data)|ONNX version|Opset version|Accuracy |
 |-------------|:--------------|:--------------|:--------------|:--------------|:--------------|
 |GPT-2       |[522.81 MB](model/gpt2-10.onnx) | [438.3 MB](model/gpt2-10.tar.gz)| 1.6 | 10 |mAP of [0.024](https://docs.google.com/spreadsheets/d/1sryqufw2D0XlUH4sq3e9Wnxu5EAQkaohzrJbd5HdQ_w/edit#gid=0)|
+|GPT-2-LM-HEAD |[664.87 MB](model/gpt2-lm-head-10.onnx) | [607 MB](model/gpt2-lm-head-10.tar.gz)| 1.6 | 10 |mAP of [0.024](https://docs.google.com/spreadsheets/d/1sryqufw2D0XlUH4sq3e9Wnxu5EAQkaohzrJbd5HdQ_w/edit#gid=0)|
 
 
 ## Inference
@@ -31,17 +32,62 @@ tokens_tensor = torch.tensor([torch.tensor(tokenizer.encode(text))])
 ```
 
 ### Output of model
+For GPT-2 model:
+
 **last_hidden_state**: Sequence of hidden-states at the last layer of the model. It's a float tensor of size (batch_size, sequence_length, hidden_size).
 **past**: pre-computed hidden-states. It's a list of tensors (key and values in the attention blocks) of size (batch_size, num_heads, sequence_length, sequence_length), one per each layer.
 
 Output of this model is the tuple (last_hidden_state, past)
 
+For GPT-2-LM-HEAD model:
+
+**prediction_scores**: Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax). It's a float tensor of size (batch_size, sequence_length, vocab_size).
+**past**: pre-computed hidden-states. It's a list of tensors (key and values in the attention blocks) of size (batch_size, num_heads, sequence_length, sequence_length), one per each layer.
+
+Output of this model is the tuple (prediction_scores, past)
+
 Note that output_hidden_states=False and output_attentions=False in the PretrainedConfig configs.
 
 ### Postprocessing steps
+For GPT-2 model:
+
 ```python
 outputs = model(input_ids)
 last_hidden_states = outputs[0]
+```
+
+For GPT-2-LM-HEAD model, to generate next 10 words:
+```
+import numpy as np
+import torch
+import torch.nn.functional as F
+from transformers import GPT2Tokenizer
+
+batch_size = 1
+length = 10
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+tokenizer = GPT2Tokenizer.from_pretrained('gpt2')
+
+text = "Here is some text to encode : Hello World!"
+tokens = np.array(tokenizer.encode(text))
+context = torch.tensor(tokens, device=device, dtype=torch.long).unsqueeze(0).repeat(batch_size, 1)
+prev = context
+output = context
+
+for i in range(length):
+    outputs = model(prev)
+    logits = outputs[0]
+    logits = logits[:, -1, :]
+    log_probs = F.softmax(logits, dim=-1)
+    _, prev = torch.topk(log_probs, k=1, dim=-1)
+    output = torch.cat((output, prev), dim=1)
+
+output = output[:, len(tokens):].tolist()
+generated = 0
+for i in range(batch_size):
+    generated += 1
+    text = tokenizer.decode(output[i])
+    print(text)
 ```
 <hr>
 
@@ -66,6 +112,7 @@ This model is converted directly from [huggingface/transformers](https://github.
 
 ## Contributors
 Negin Raoof
+Joddiy Zhang
 <hr>
 
 ## License

--- a/text/machine_comprehension/gpt-2/README.md
+++ b/text/machine_comprehension/gpt-2/README.md
@@ -14,6 +14,11 @@ Transformer-based language model for text generation.
 |GPT-2-LM-HEAD |[664.87 MB](model/gpt2-lm-head-10.onnx) | [607 MB](model/gpt2-lm-head-10.tar.gz)| 1.6 | 10 |mAP of [0.024](https://docs.google.com/spreadsheets/d/1sryqufw2D0XlUH4sq3e9Wnxu5EAQkaohzrJbd5HdQ_w/edit#gid=0)|
 
 
+### Source
+PyTorch GPT-2 ==> ONNX GPT-2  
+PyTorch GPT-2 + script changes ==> ONNX GPT-2-LM-HEAD
+
+
 ## Inference
 The script for ONNX model conversion and ONNX Runtime inference is [here](dependencies/GPT2-export.py).
 

--- a/text/machine_comprehension/gpt-2/dependencies/GPT2-export.py
+++ b/text/machine_comprehension/gpt-2/dependencies/GPT2-export.py
@@ -2,14 +2,17 @@ import torch
 import onnxruntime
 import onnx
 from onnx import numpy_helper
-from transformers import GPT2Model, GPT2Tokenizer
+from transformers import GPT2Model, GPT2LMHeadModel, GPT2Tokenizer
 
 import numpy as np
 import os
 
-#          Model          | Tokenizer          | Pretrained weights shortcut
+# Transformers has a unified API
+# for 8 transformer architectures and 30 pretrained weights.
+#          Model          | Tokenizer          | Pretrained weights shortcut          | save_name
 MODELS = [
-    (GPT2Model, GPT2Tokenizer, 'gpt2'),
+    (GPT2Model, GPT2Tokenizer, 'gpt2', 'gpt2'),
+    (GPT2LMHeadModel, GPT2Tokenizer, 'gpt2', 'gpt2-lm-head'),
 ]
 data_dir = 'test_data_set_0'
 
@@ -111,7 +114,7 @@ def inference(file, inputs, outputs):
 
 
 def gpt2_test():
-    for model_class, tokenizer_class, pretrained_weights in MODELS:
+    for model_class, tokenizer_class, pretrained_weights, save_name in MODELS:
         # Load pretrained model/tokenizer
         tokenizer = tokenizer_class.from_pretrained(pretrained_weights)
         model = model_class.from_pretrained(pretrained_weights)
@@ -123,7 +126,7 @@ def gpt2_test():
         with torch.no_grad():
             output_1 = model(input_ids_1)  # Models outputs are now tuples
 
-        model_dir, data_dir = save_model('gpt2', model.cpu(), input_ids_1, output_1,
+        model_dir, data_dir = save_model(save_name, model.cpu(), input_ids_1, output_1,
                                          opset_version=10,
                                          input_names=['input1'],
                                          dynamic_axes={'input1': [0, 1, 2, 3]})

--- a/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.onnx
+++ b/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:519650b01bc3dfa0b556fbe6d76ab3938ec6c70310b49ba31ddc3024be3641ad
+size 664870493

--- a/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.tar.gz
+++ b/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0991483d79aa7d25d5f045e8f9f9e6129713f7529867d3ff3b72f3d9a0a7ee3
+size 607004416


### PR DESCRIPTION
When we use the GPT-2 onnx model, we want to generate new words by it. However, the current GPT-2 model only gives the last hidden states, rather than the next word's prediction.

So based on the previous work, this PR tries to add GPT2LMHeadModel, including editing the export script and postprocessing code.