### PR TITLE
move CI to github actions

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -1,0 +1,38 @@
+# Basic linux ci workflow for model zoo.
+# Runs model checker for models updated in the PR
+
+name: Linux CI
+
+# Triggers the workflow on push or pull request events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+        architecture: ['x64']
+        onnx-version: ['1.7']
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout repo
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+
+      - name: Install dependencies and test ONNX models
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install onnx==${{ matrix.onnx-version }} requests
+          python .azure-pipelines/test_models.py

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -1,0 +1,38 @@
+# Basic windows ci workflow for model zoo.
+# Runs model checker for models updated in the PR
+
+name: Windows CI
+
+# Triggers the workflow on push or pull request events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+        architecture: ['x64']
+        onnx-version: ['1.7']
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout repo
+        
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      
+      - name: Install dependencies and test ONNX models
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install onnx==${{ matrix.onnx-version }} requests
+          python .azure-pipelines/test_models.py


### PR DESCRIPTION
This is Part 1 PR for moving CIs to github actions.

Part 1 - Add github actions for CI
Part 2- Thoroughly test github actions and deprecate azure pipelines