### PR TITLE
Fixed documentation for tiny-yolov3 post processing

### DIFF
--- a/vision/object_detection_segmentation/tiny-yolov3/README.md
+++ b/vision/object_detection_segmentation/tiny-yolov3/README.md
@@ -67,7 +67,7 @@ indices: `('nbox'x3)`, selected indices from the boxes tensor. The selected inde
 Post processing and meaning of output
 ```python
 out_boxes, out_scores, out_classes = [], [], []
-for idx_ in indices:
+for idx_ in indices[0]:
     out_classes.append(idx_[1])
     out_scores.append(scores[tuple(idx_)])
     idx_1 = (idx_[0], idx_[2])


### PR DESCRIPTION
# Model Name
tiny-yolov3

## Description
The post processing step documented for tiny yolov3 does not work out of the box. The `indices` from the inference output is of a different shape, and the for .. in loop crashes due to it. 

It has been corrected by replacing `for idx_ in indices:` to `for idx_ in indices[0]:`.
This fix is inspired from the test case [here](https://github.com/onnx/keras-onnx/blob/master/applications/nightly_build/test_yolov3.py#L42).

