### PR TITLE
Fix input and output shape/data type in roberta-sequence-classificati…

### DIFF
--- a/text/machine_comprehension/roberta/model/roberta-sequence-classification-9.tar.gz
+++ b/text/machine_comprehension/roberta/model/roberta-sequence-classification-9.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd8823580d0ae91a2a836e6e2005082bf63a7818e405c4fc83a9aafc43f6252c
-size 431796013
+oid sha256:149f8aa33713d9ae0411cee5cdc47107bafe771e93f590de6c082b45b2f6984d
+size 431685676


### PR DESCRIPTION
…on-9 model

Model expects input to have data type int64 and shape (batch_size, sequence_length) -
while current input tensor has float64 and (1, 1, 6) shape.
Regarding the output - model expects float32 data type and (batch_size, 2) shape -
while current output tensor has float64 and (1, 1, 1, 2) shape.

Signed-off-by: Mateusz Tabaka <mateusz.tabaka@intel.com>