### PR TITLE
Fix output tensors in Yolo v4 model

### DIFF
--- a/vision/object_detection_segmentation/yolov4/model/yolov4.tar.gz
+++ b/vision/object_detection_segmentation/yolov4/model/yolov4.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:761000c4afb2979fbf07c0db80821b3105dadacac2da2cbb3a45379b7286b13d
-size 241871897
+oid sha256:b2fce1287242740a139bc8b15cf463fd4b50f15f480f1461d70e454f75ed0404
+size 248665735


### PR DESCRIPTION
Seems like the outputs were the copies of the inputs.
New outputs are generated with onnxruntime and grouped in test_data_set_* directories.

Signed-off-by: Mateusz Tabaka <mateusz.tabaka@intel.com>