### PR TITLE
Remove unnecessary reshape in mnist-1 model

### DIFF
--- a/vision/classification/mnist/model/mnist-1.onnx
+++ b/vision/classification/mnist/model/mnist-1.onnx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7f5c24ca1b64afa718bad19795b88dcf34c424877d367a95a0b9bdb6e57288b
-size 27349
+oid sha256:22239f3fcc38f34d02eecd6869aed15b93f8e3e1125dda48990d244a5e113d49
+size 27266

--- a/vision/classification/mnist/model/mnist-1.tar.gz
+++ b/vision/classification/mnist/model/mnist-1.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80c8cc33bf5c167df92a166c87498da7411b89331fbd55935397aeea2afb3ff1
-size 26350
+oid sha256:a296485a657137a78b5c9b0ade09fca4041364da2c530dd0edfca1e1bb53283e
+size 26518


### PR DESCRIPTION
This is how the model was changed:
```
-- model.prototxt.orig 2020-12-22 12:16:40.634961643 +0100
+++ model.prototxt      2020-12-22 12:18:40.589855609 +0100
@@ -6409,21 +6409,8 @@
     domain: ""
   }
   node {
-    input: "Constant367"
-    output: "Reshape420_Output_0"
-    name: "Reshape420"
-    op_type: "Reshape"
-    attribute {
-      name: "shape"
-      ints: 10
-      type: INTS
-    }
-    doc_string: ""
-    domain: ""
-  }
-  node {
     input: "Times418_Output_0"
-    input: "Reshape420_Output_0"
+    input: "Constant367"
     output: "Plus422_Output_0"
     name: "Plus214"
     op_type: "Add"
```

The unnecessary node did reshape of Constant367 (which has shape [1, 10]) to shape [10],
and the output of that operation was passed as a second input to Add node (named "Plus214").
Since first input to "Plus214" node has shape [1, 10], reshape described above
made the model incorrect because input shapes to Add operator didn't match and its broadcast attribute is set to 0.