### PR TITLE
Skip ORT backend test if the model has opset<7

### DIFF
--- a/workflow_scripts/check_model.py
+++ b/workflow_scripts/check_model.py
@@ -9,6 +9,10 @@ def run_onnx_checker(model_path):
     onnx.checker.check_model(model)
 
 def run_backend_ort(model_path, test_data_set=None):
+    model = onnx.load(model_path)
+    if model.opset_import[0].version < 7:
+        print('Skip ORT test since it only *guarantees* support for models stamped with opset version 7')
+        return
     # if 'test_data_set_N' doesn't exist, create test_dir
     if not test_data_set:
         onnxruntime.InferenceSession(model_path)


### PR DESCRIPTION
**Description**
Skip ORT backend test if the model has opset<7.

**Motivation**
ONNXRuntime only *guarantees* support for models stamped with opset version 7.
Unblock this PR https://github.com/onnx/models/pull/411 by skipping the inexecutable test.