### PR TITLE
Fix the broken url in contribute.md

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -1,5 +1,5 @@
 # How to Contribute to the Model Zoo
 
-To contribute a new model, create a [pull request](https://github.com/onnx/models/pull/new/). A pre-defined pull request [template](PULL_REQUEST_TEMPLATE.md) is loaded when creating a new pull request, which describes all the artifacts required for making the contribution.
+To contribute a new model, create a [pull request](https://github.com/onnx/models/pull/new/). A pre-defined pull request [template](.github/PULL_REQUEST_TEMPLATE.md) is loaded when creating a new pull request, which describes all the artifacts required for making the contribution.
 
 View an [example submission](vision/classification/resnet/README.md) to get a sense of the final output.


### PR DESCRIPTION
Fix the broken url in contribute.md: use `.github/PULL_REQUEST_TEMPLATE.md` instead of `PULL_REQUEST_TEMPLATE` because the document has been moved.