### PR TITLE
Change BertSquad-10 expected results order

### DIFF
--- a/text/machine_comprehension/bert-squad/model/bertsquad-10.tar.gz
+++ b/text/machine_comprehension/bert-squad/model/bertsquad-10.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a00c20d430308166a3bc95e0688f60a016dc87cfcde8108210a1a43f33b2df3
-size 403082467
+oid sha256:5ed61ab22c90db6928e88fad21f72217b04d6b5ed249c92de46321f77a6f35c3
+size 403081843


### PR DESCRIPTION
Fixing expected result merged in https://github.com/onnx/models/pull/418 was fine but I've observed another problems:

1. Outputs in Bertsquad-10 ONNX model are in order:
- `unstack:1`
- `unstack:0`
- `unique_ids:0`
but expected outputs are saved as:
output_0.pb -> `unique_ids:0`
output_1.pb -> `unstack:0`
output_2.pb -> `unstack:1`
The order was fixed.

2. The second minor thing was incorrect folder name: `download_sample_10` after unpacking `bertsquad-10.tar.gz`.
It was changed to `bertsquad-10`.