### PR TITLE
[Mobilenetv2] Add missing test data

### DIFF
--- a/vision/classification/mobilenet/model/mobilenetv2-7.tar.gz
+++ b/vision/classification/mobilenet/model/mobilenetv2-7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:147af1703264c68d6e0880b3f807bf43fd5ada98d2df6b4c4aec3be6ac26d6f2
+size 14570532

--- a/vision/classification/mobilenet/model/mobilnetv2-7.tar.gz
+++ b/vision/classification/mobilenet/model/mobilnetv2-7.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d50e33a9edc8e2a416858c209fdeccb0860bd057d0a9a031ee1ec0c6b6d35463
-size 12936800


### PR DESCRIPTION
After merge https://github.com/onnx/models/pull/410 there are missing test data to Mobilenetv2 in `mobilnetv2-7.tar.gz`
I used inputs from version before #410 update and generate outputs using onnx runtime (1.6.0) on current version of model.
(minor - The name of package was changed to `mobilenetv2-7.tar.gz`)
