### PR TITLE
add int8 efficientnet, inceptionv1, ssdmbv1, ssd, fcn_rn50

### DIFF
--- a/vision/classification/efficientnet-lite4/README.md
+++ b/vision/classification/efficientnet-lite4/README.md
@@ -10,13 +10,19 @@ EfficientNet-Lite 4 is the largest variant and most accurate of the set of Effic
 
 ## Model
 
- |Model        |Download | Download (with sample test data)|ONNX version|Opset version|
-|-------------|:--------------|:--------------|:--------------|:--------------|
-|EfficientNet-Lite4     | [51.9 MB](model/efficientnet-lite4-11.onnx)	  | [48.6 MB](model/efficientnet-lite4-11.tar.gz)|1.7.0|11|
-
+ |Model        |Download | Download (with sample test data)|ONNX version|Opset version|Top-1 accuracy (%)|
+|-------------|:--------------|:--------------|:--------------|:--------------|:--------------|
+|EfficientNet-Lite4     | [51.9 MB](model/efficientnet-lite4-11.onnx)	  | [48.6 MB](model/efficientnet-lite4-11.tar.gz)|1.7.0|11|80.4|
+|EfficientNet-Lite4-int8     | [13.0 MB](model/efficientnet-lite4-11-int8.onnx)	  | [12.2 MB](model/efficientnet-lite4-11-int8.tar.gz)|1.9.0|11|77.56|
+> The fp32 Top-1 accuracy got by [Intel® Neural Compressor](https://github.com/intel/neural-compressor) is 77.70%, and compared with this value, int8 EfficientNet-Lite4's Top-1 accuracy drop ratio is 0.18% and performance improvement is 1.12x.
+>
+> **Note** 
+>
+> The performance depends on the test hardware. Performance data here is collected with Intel® Xeon® Platinum 8280 Processor, 1s 4c per instance, CentOS Linux 8.3, data batch size is 1.
 
 ### Source
 Tensorflow EfficientNet-Lite4 => ONNX EfficientNet-Lite4
+ONNX EfficientNet-Lite4 => Quantized ONNX EfficientNet-Lite4
 
 <hr>
 
@@ -132,14 +138,43 @@ The model was trained using [COCO 2017 Train Images, Val Images, and Train/Val a
 Refer to [efficientnet-lite4 conversion notebook](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/efficientnet-lite.ipynb) for details of how to use it and reproduce accuracy.
 <hr>
 
-## References
-Tensorflow to Onnx conversion [tutorial](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/efficientnet-lite.ipynb). The Juypter Notebook references how to run an evaluation on the efficientnet-lite4 model and export it as a saved model. It also details how to convert the tensorflow model into onnx, and how to run its preprocessing and postprocessing code for the inputs and outputs.
+## Quantization
+CaffeNet-int8 is obtained by quantizing fp32 CaffeNet model. We use [Intel® Neural Compressor](https://github.com/intel/neural-compressor) with onnxruntime backend to perform quantization. View the [instructions](https://github.com/intel/neural-compressor/blob/master/examples/onnxrt/image_recognition/onnx_model_zoo/efficientnet/quantization/ptq/README.md) to understand how to use Intel® Neural Compressor for quantization.
 
-Refer to this [paper](https://arxiv.org/abs/1905.11946) for more details on the model.
+### Environment
+onnx: 1.9.0 
+onnxruntime: 1.8.0
+
+### Prepare model
+```shell
+wget https://github.com/onnx/models/raw/master/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx
+```
+
+### Model quantize
+Make sure to specify the appropriate dataset path in the configuration file.
+```bash
+bash run_tuning.sh --input_model=path/to/model \  # model path as *.onnx
+                   --config=efficientnet.yaml \
+                   --output_model=path/to/save
+```
+<hr>
+
+## References
+* Tensorflow to Onnx conversion [tutorial](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/efficientnet-lite.ipynb). The Juypter Notebook references how to run an evaluation on the efficientnet-lite4 model and export it as a saved model. It also details how to convert the tensorflow model into onnx, and how to run its preprocessing and postprocessing code for the inputs and outputs.
+
+* Refer to this [paper](https://arxiv.org/abs/1905.11946) for more details on the model.
+
+* [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
+
 <hr>
 
 ## Contributors
- [Shirley Su](https://github.com/shirleysu8)
+* [Shirley Su](https://github.com/shirleysu8)
+* [mengniwang95](https://github.com/mengniwang95) (Intel)
+* [airMeng](https://github.com/airMeng) (Intel)
+* [ftian1](https://github.com/ftian1) (Intel)
+* [hshen14](https://github.com/hshen14) (Intel)
+
 <hr>
 
 ## License

--- a/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11-int8.onnx
+++ b/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11-int8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b3cbb5077262b20df565dacddecb3724c0976c35029a87e512d13aa4eff04a2
+size 13585963

--- a/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11-int8.tar.gz
+++ b/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11-int8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b03546fb343ba48e3243c893ea37e47cb1f337d80ed0aca562077d8d3da51b6
+size 12780764

--- a/vision/classification/inception_and_googlenet/inception_v1/README.md
+++ b/vision/classification/inception_and_googlenet/inception_v1/README.md
@@ -2,25 +2,31 @@
 
 # Inception v1
 
-|Model        |Download  |Download (with sample test data)| ONNX version |Opset version|
-| ------------- | ------------- | ------------- | ------------- | ------------- |
-|Inception-1| [28 MB](model/inception-v1-3.onnx)  |  [29 MB](model/inception-v1-3.tar.gz) |  1.1 | 3|
-|Inception-1| [28 MB](model/inception-v1-6.onnx)  |  [29 MB](model/inception-v1-6.tar.gz) |  1.1.2 | 6|
-|Inception-1| [28 MB](model/inception-v1-7.onnx)  |  [29 MB](model/inception-v1-7.tar.gz) |  1.2 | 7|
-|Inception-1| [28 MB](model/inception-v1-8.onnx)  |  [29 MB](model/inception-v1-8.tar.gz) |  1.3 | 8|
-|Inception-1| [28 MB](model/inception-v1-9.onnx)  |  [29 MB](model/inception-v1-9.tar.gz) |  1.4 | 9|
+|Model        |Download  |Download (with sample test data)| ONNX version |Opset version| Top-1 accuracy (%)|
+| ------------- | ------------- | ------------- | ------------- | ------------- |------------- |
+|Inception-1| [28 MB](model/inception-v1-3.onnx)  |  [29 MB](model/inception-v1-3.tar.gz) |  1.1 | 3| |
+|Inception-1| [28 MB](model/inception-v1-6.onnx)  |  [29 MB](model/inception-v1-6.tar.gz) |  1.1.2 | 6| |
+|Inception-1| [28 MB](model/inception-v1-7.onnx)  |  [29 MB](model/inception-v1-7.tar.gz) |  1.2 | 7| |
+|Inception-1| [28 MB](model/inception-v1-8.onnx)  |  [29 MB](model/inception-v1-8.tar.gz) |  1.3 | 8| |
+|Inception-1| [28 MB](model/inception-v1-9.onnx)  |  [29 MB](model/inception-v1-9.tar.gz) |  1.4 | 9| |
+|Inception-1| [27 MB](model/inception-v1-12.onnx)  |  [25 MB](model/inception-v1-12.tar.gz) |  1.9 | 12| 67.23|
+|Inception-1-int8| [10 MB](model/inception-v1-12-int8.onnx)  |  [9 MB](model/inception-v1-12-int8.tar.gz) |  1.9 | 12| 67.24|
+> Compared with the fp32 Inception-1, int8 Inception-1's Top-1 accuracy drop ratio is -0.01% and performance improvement is 1.26x.
+>
+> **Note** 
+> 
+> The performance depends on the test hardware. Performance data here is collected with Intel® Xeon® Platinum 8280 Processor, 1s 4c per instance, CentOS Linux 8.3, data batch size is 1.
+
 
 ## Description
 Inception v1 is a reproduction of GoogLeNet.
-
-### Paper
-[Going deeper with convolutions](https://arxiv.org/abs/1409.4842)
 
 ### Dataset
 [ILSVRC2012](http://www.image-net.org/challenges/LSVRC/2012/)
 
 ## Source
 Caffe2 Inception v1 ==> ONNX Inception v1
+ONNX Inception v1 ==> Quantized ONNX Inception v1
 
 ## Model input and output
 ### Input
@@ -43,6 +49,40 @@ random generated sampe test data:
 - test_data_set_2
 
 ## Results/accuracy on test set
+
+## Quantization
+Inception-1-int8 is obtained by quantizing fp32 Inception-1 model. We use [Intel® Neural Compressor](https://github.com/intel/neural-compressor) with onnxruntime backend to perform quantization. View the [instructions](https://github.com/intel/neural-compressor/blob/master/examples/onnxrt/image_recognition/onnx_model_zoo/inception/quantization/ptq/README.md) to understand how to use Intel® Neural Compressor for quantization.
+
+### Environment
+onnx: 1.9.0 
+onnxruntime: 1.8.0
+
+### Prepare model
+```shell
+wget https://github.com/onnx/models/blob/master/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12.onnx
+```
+
+### Model quantize
+Make sure to specify the appropriate dataset path in the configuration file.
+```bash
+bash run_tuning.sh --input_model=path/to/model \  # model path as *.onnx
+                   --config=inception_v1.yaml \
+                   --data_path=/path/to/imagenet \
+                   --label_path=/path/to/imagenet/label \
+                   --output_model=path/to/save
+```
+
+## References
+* [Going deeper with convolutions](https://arxiv.org/abs/1409.4842)
+
+* [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
+
+
+## Contributors
+* [mengniwang95](https://github.com/mengniwang95) (Intel)
+* [airMeng](https://github.com/airMeng) (Intel)
+* [ftian1](https://github.com/ftian1) (Intel)
+* [hshen14](https://github.com/hshen14) (Intel)
 
 ## License
 MIT

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12-int8.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12-int8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d25f0bfa7a92e9a67d8049facd4454911ca4388a303fc61ee14664b1010c717
+size 10191535

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12-int8.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12-int8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:296e49e0f1253877053d5aa48f4192f675b302b5828e70a821d6d94e0c8ee4e3
+size 9463738

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12.onnx
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:814b31a6316873bd03d2d808415ce1f40a7bf48ad88eab5ecc3cdc8dc6cf38ec
+size 28021958

--- a/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12.tar.gz
+++ b/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-12.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4198ed3415d59dacab2f6fa90c81f1a3aa9f3623b66e2d9653f16d06a5cc68c
+size 26545542

--- a/vision/object_detection_segmentation/fcn/README.md
+++ b/vision/object_detection_segmentation/fcn/README.md
@@ -14,7 +14,7 @@ This specific model detects 20 different [classes](dependencies/voc_classes.txt)
 | FCN ResNet-50  | [134 MB](model/fcn-resnet50-11.onnx)  | [213 MB](model/fcn-resnet50-11.tar.gz)  | 1.8.0        | 11 | 60.5% |
 | FCN ResNet-101 | [207 MB](model/fcn-resnet101-11.onnx) | [281 MB](model/fcn-resnet101-11.tar.gz) | 1.8.0        | 11 | 63.7% |
 | FCN ResNet-50  | [134 MB](model/fcn-resnet50-12.onnx)  | [125 MB](model/fcn-resnet50-12.tar.gz)  | 1.8.0        | 12 | 60.5% |
-| FCN ResNet-50-int8  | [34 MB](model/fcn-resnet50-int8-12.onnx)  | [29 MB](model/fcn-resnet50-12-int8.tar.gz)  | 1.8.0        | 12 | 64.7% |
+| FCN ResNet-50-int8  | [34 MB](model/fcn-resnet50-12-int8.onnx)  | [29 MB](model/fcn-resnet50-12-int8.tar.gz)  | 1.8.0        | 12 | 64.7% |
 
 ### Source
 

--- a/vision/object_detection_segmentation/fcn/README.md
+++ b/vision/object_detection_segmentation/fcn/README.md
@@ -13,11 +13,14 @@ This specific model detects 20 different [classes](dependencies/voc_classes.txt)
 |----------------|:--------------------------------------|:----------------------------------------|:-------------|:--------------|:--------|
 | FCN ResNet-50  | [134 MB](model/fcn-resnet50-11.onnx)  | [213 MB](model/fcn-resnet50-11.tar.gz)  | 1.8.0        | 11 | 60.5% |
 | FCN ResNet-101 | [207 MB](model/fcn-resnet101-11.onnx) | [281 MB](model/fcn-resnet101-11.tar.gz) | 1.8.0        | 11 | 63.7% |
+| FCN ResNet-50  | [134 MB](model/fcn-resnet50-12.onnx)  | [125 MB](model/fcn-resnet50-12.tar.gz)  | 1.8.0        | 12 | 60.5% |
+| FCN ResNet-50-int8  | [34 MB](model/fcn-resnet50-int8-12.onnx)  | [29 MB](model/fcn-resnet50-12-int8.tar.gz)  | 1.8.0        | 12 | 64.7% |
 
 ### Source
 
  * PyTorch Torchvision FCN ResNet50 ==> ONNX FCN ResNet50
  * PyTorch Torchvision FCN ResNet101 ==> ONNX FCN ResNet101
+ * ONNX FCN ResNet50 ==> Quantized ONNX FCN ResNet50
 
 ## Inference
 
@@ -129,18 +132,53 @@ If you have the [COCO val2017 dataset](https://cocodataset.org/#download) downlo
 | Model          | mean IoU | global pixelwise accuracy |
 |----------------|:---------|:--------------------------|
 | FCN ResNet 50  | 65.0     | 99.6                      |
+| FCN ResNet 50-int8 | 64.7 | 99.5                      |
 | FCN ResNet 101 | 66.7     | 99.6                      |
 
 The more conservative of the two estimates is used in the model files table.
+
+> Compared with the fp32 FCN ResNet 50, FCN ResNet 50-int8's mean IoU drop ratio is 0.46% global pixelwise accuracy drop ratio is 0.10% and performance improvement is 1.28x.
+>
+> **Note**
+>
+>The performance depends on the test hardware. Performance data here is collected with Intel® Xeon® Platinum 8280 Processor, 1s 4c per inst ance, CentOS Linux 8.3, data batch size is 1.
 <hr>
 
-## References
-Jonathan Long, Evan Shelhamer, Trevor Darrell; Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2015, pp. 3431-3440
+## Quantization
+FCN ResNet 50-int8 is obtained by quantizing fp32 FCN ResNet 50 model. We use [Intel® Neural Compressor](https://github.com/intel/neural-compressor) with onnxruntime backend to perform quantization. View the [instructions](https://github.com/intel/neural-compressor/blob/master/examples/onnxrt/image_recognition/onnx_model_zoo/fcn/quantization/ptq/README.md) to understand how to use Intel® Neural Compressor for quantization.
 
-This model is converted from the [Torchvision Model Zoo](https://pytorch.org/docs/stable/torchvision/models.html), originally implemented by Francisco Moss [here](https://github.com/pytorch/vision/tree/master/torchvision/models/segmentation/fcn.py).
+### Environment
+onnx: 1.9.0 
+onnxruntime: 1.8.0
+
+### Prepare model
+```shell
+wget https://github.com/onnx/models/raw/master/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12.onnx
+```
+
+### Model quantize
+Make sure to specify the appropriate dataset path in the configuration file.
+```bash
+bash run_tuning.sh --input_model=path/to/model  \ # model path as *.onnx
+                   --config=fcn_rn50.yaml \ 
+                   --data_path=path/to/coco/val2017 \
+                   --label_path=path/to/coco/annotations/instances_val2017.json \
+                   --output_model=path/to/save
+```
+
+## References
+* Jonathan Long, Evan Shelhamer, Trevor Darrell; Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition (CVPR), 2015, pp. 3431-3440
+
+* This model is converted from the [Torchvision Model Zoo](https://pytorch.org/docs/stable/torchvision/models.html), originally implemented by Francisco Moss [here](https://github.com/pytorch/vision/tree/master/torchvision/models/segmentation/fcn.py).
+
+* [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
 
 ## Contributors
-[Jack Duvall](https://github.com/duvallj)
+* [Jack Duvall](https://github.com/duvallj)
+* [mengniwang95](https://github.com/mengniwang95) (Intel)
+* [airMeng](https://github.com/airMeng) (Intel)
+* [ftian1](https://github.com/ftian1) (Intel)
+* [hshen14](https://github.com/hshen14) (Intel)
 
 ## License
 MIT License

--- a/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12-int8.onnx
+++ b/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12-int8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67fcba8ebd435c2fb6b297d2e7c084f3c3b9ae6bc7ae41453b748ae4ed8c0331
+size 35545058

--- a/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12-int8.tar.gz
+++ b/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12-int8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e81dd5cd5625e8c544f92429e36028596b88d0574ccf72c8ebc48174508cb29
+size 30117697

--- a/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12.onnx
+++ b/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb5017d1b80372eb0b58552655274698817ba2e774437e2c2d3c0a613d2e99bd
+size 141193555

--- a/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12.tar.gz
+++ b/vision/object_detection_segmentation/fcn/model/fcn-resnet50-12.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:470813ecd5791f20f7b21c54765d8eae51b22bcf2ece668656384476f97d6075
+size 131124463

--- a/vision/object_detection_segmentation/ssd-mobilenetv1/README.md
+++ b/vision/object_detection_segmentation/ssd-mobilenetv1/README.md
@@ -12,12 +12,20 @@ The SSD-MobilenetV1 is suitable for mobile and embedded vision applications.
 
 ## Model
 
-|Model        |Download  | Download (with sample test data)|ONNX version|Opset version|
-|-------------|:--------------|:--------------|:--------------|:--------------|
-|SSD-MobilenetV1       | [29.3 MB](model/ssd_mobilenet_v1_10.onnx)  |[27.9 MB](model/ssd_mobilenet_v1_10.tar.gz) |1.7.0 | 10 |
+|Model        |Download  | Download (with sample test data)|ONNX version|Opset version| mAP |
+|-------------|:--------------|:--------------|:--------------|:--------------|:--------------|
+|SSD-MobilenetV1       | [29.3 MB](model/ssd_mobilenet_v1_10.onnx)  |[27.9 MB](model/ssd_mobilenet_v1_10.tar.gz) |1.7.0 | 10 | |
+|SSD-MobilenetV1-12       | [28.1 MB](model/ssd_mobilenet_v1_12.onnx)  |[24.3 MB](model/ssd_mobilenet_v1_12.tar.gz) |1.9.0 | 12 |0.2303 |
+|SSD-MobilenetV1-12-int8       | [8.5 MB](model/ssd_mobilenet_v1_12-int8.onnx)  |[5.5 MB](model/ssd_mobilenet_v1_12-int8.tar.gz) |1.9.0 | 12 |0.2285 |
+> Compared with the fp32 SSD-MobilenetV1-12, int8 SSD-MobilenetV1-12's mAP drop ratio is 0.78% and performance improvement is 1.15x.
+>
+> **Note** 
+>
+> The performance depends on the test hardware. Performance data here is collected with Intel® Xeon® Platinum 8280 Processor, 1s 4c per instance, CentOS Linux 8.3, data batch size is 1.
 
 ### Source
 Tensorflow SSD-MobileNetV1 ==> ONNX SSD-MobileNetV1
+ONNX SSD-MobileNetV1 ==> Quantized ONNX SSD-MobileNetV1
 
 ## Inference
 
@@ -134,12 +142,37 @@ The model was trained using [MS COCO 2017 Train Images, Val Images, and Train/Va
 Training details for the SSD-MobileNet model's preprocessing is found in this [tutorial notebook](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/ConvertingSSDMobilenetToONNX.ipynb).
 The notebook also details how the ONNX model was converted.
 
-### References
-Tensorflow to ONNX conversion [tutorial](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/ConvertingSSDMobilenetToONNX.ipynb). The notebook references how to run an evaluation on the SSD-MobilenetV1 model and export it as a saved model. It also details how to convert the tensorflow model into onnx, and how to run its preprocessing and postprocessing code for the inputs and outputs.
+## Quantization
+SSD-MobilenetV1-12-int8 is obtained by quantizing fp32 SSD-MobilenetV1-12 model. We use [Intel® Neural Compressor](https://github.com/intel/neural-compressor) with onnxruntime backend to perform quantization. View the [instructions](https://github.com/intel/neural-compressor/blob/master/examples/onnxrt/object_detection/onnx_model_zoo/ssd_mobilenet_v1/quantization/ptq/README.md) to understand how to use Intel® Neural Compressor for quantization.
 
+### Environment
+onnx: 1.9.0 
+onnxruntime: 1.8.0
+
+### Prepare model
+```shell
+wget https://github.com/onnx/models/raw/master/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12.onnx
+```
+
+### Model quantize
+Make sure to specify the appropriate dataset path in the configuration file.
+```bash
+bash run_tuning.sh --input_model=path/to/model  \ # model path as *.onnx
+                   --config=ssd_mobilenet_v1.yaml \ 
+                   --output_model=path/to/save
+```
+
+### References
+* Tensorflow to ONNX conversion [tutorial](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/ConvertingSSDMobilenetToONNX.ipynb). The notebook references how to run an evaluation on the SSD-MobilenetV1 model and export it as a saved model. It also details how to convert the tensorflow model into onnx, and how to run its preprocessing and postprocessing code for the inputs and outputs.
+
+* [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
 
 ## Contributors
-[Shirley Su](https://github.com/shirleysu8)
+* [Shirley Su](https://github.com/shirleysu8)
+* [mengniwang95](https://github.com/mengniwang95) (Intel)
+* [airMeng](https://github.com/airMeng) (Intel)
+* [ftian1](https://github.com/ftian1) (Intel)
+* [hshen14](https://github.com/hshen14) (Intel)
 
 ## License
 MIT License

--- a/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12-int8.onnx
+++ b/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12-int8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45af75d9ddb063744277887ee27a658f7759980f7c1a87e21b53a11e7ae59627
+size 8958931

--- a/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12-int8.tar.gz
+++ b/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12-int8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39a0e207a731374c6a186de474ce937f8c277a20f0b4fd04cf43db56fb6047f5
+size 5778852

--- a/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12.onnx
+++ b/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8fba5e404077d4048d27fcd1667e85e27e192eb9bf51e696c46a3acd7d21058
+size 29461455

--- a/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12.tar.gz
+++ b/vision/object_detection_segmentation/ssd-mobilenetv1/model/ssd_mobilenet_v1_12.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb7485300ba8379f963e47278d3940cebeedba1fd1370b374aac733414d7cf9b
+size 25475584

--- a/vision/object_detection_segmentation/ssd/README.md
+++ b/vision/object_detection_segmentation/ssd/README.md
@@ -10,8 +10,14 @@ This model is a real-time neural network for object detection that detects 80 di
 |Model        |Download  | Download (with sample test data)|ONNX version|Opset version|Accuracy |
 |-------------|:--------------|:--------------|:--------------|:--------------|:--------------|
 |SSD       |[80.4 MB](model/ssd-10.onnx) | [78.5 MB](model/ssd-10.tar.gz) |1.5 |10 |mAP of 0.195 |
+|SSD       |[77.6 MB](model/ssd-12.onnx) | [86.4 MB](model/ssd-12.tar.gz) |1.9 |12 |mAP of 0.1898 |
+|SSD-int8|[19.5 MB](model/ssd-12-int8.onnx) | [30.3 MB](model/ssd-12-int8.tar.gz) |1.9 |12 |mAP of 0.1882 |
 
-
+> Compared with the fp32 SSD, SSD-int8's mAP drop ratio is 0.84% and performance improvement is 1.53x.
+>
+> **Note**
+>
+> The performance depends on the test hardware. Performance data here is collected with Intel® Xeon® Platinum 8280 Processor, 1s 4c per instance, CentOS Linux 8.3, data batch size is 1.
 
 <hr>
 
@@ -69,8 +75,38 @@ Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott Reed, Cheng-
 Backbone is ResNet34 pretrained on ILSVRC 2012 (from torchvision). Modifications to the backbone networks: remove conv_5x residual blocks, change the first 3x3 convolution of the conv_4x block from stride 2 to stride1 (this increases the resolution of the feature map to which detector heads are attached), attach all 6 detector heads to the output of the last conv_4x residual block. Thus detections are attached to 38x38, 19x19, 10x10, 5x5, 3x3, and 1x1 feature maps. Convolutions in the detector layers are followed by batch normalization layers.
 <hr>
 
+## Quantization
+SSD-int8 is obtained by quantizing fp32 SSD model. We use [Intel® Neural Compressor](https://github.com/intel/neural-compressor) with onnxruntime backend to perform quantization. View the [instructions](https://github.com/intel/neural-compressor/blob/master/examples/onnxrt/object_detection/onnx_model_zoo/ssd/quantization/ptq/README.md) to understand how to use Intel® Neural Compressor for quantization.
+
+### Environment
+onnx: 1.9.0 
+onnxruntime: 1.8.0
+
+### Prepare model
+```shell
+wget https://github.com/onnx/models/blob/master/vision/object_detection_segmentation/ssd/model/ssd-12.onnx
+```
+
+### Model quantize
+Make sure to specify the appropriate dataset path in the configuration file.
+```bash
+bash run_tuning.sh --input_model=path/to/model \  # model path as *.onnx
+                   --config=ssd.yaml \
+                   --output_model=path/to/save
+```
+<hr>
+
 ## References
-This model is converted from mlperf/inference [repository](https://github.com/mlperf/inference/tree/master/others/cloud/single_stage_detector) with modifications in [repository](https://github.com/BowenBao/inference/tree/master/cloud/single_stage_detector/pytorch).
+* This model is converted from mlperf/inference [repository](https://github.com/mlperf/inference/tree/master/others/cloud/single_stage_detector) with modifications in [repository](https://github.com/BowenBao/inference/tree/master/cloud/single_stage_detector/pytorch).
+
+* [Intel® Neural Compressor](https://github.com/intel/neural-compressor)
+<hr>
+
+## Contributors
+* [mengniwang95](https://github.com/mengniwang95) (Intel)
+* [airMeng](https://github.com/airMeng) (Intel)
+* [ftian1](https://github.com/ftian1) (Intel)
+* [hshen14](https://github.com/hshen14) (Intel)
 <hr>
 
 ## License

--- a/vision/object_detection_segmentation/ssd/model/ssd-12-int8.onnx
+++ b/vision/object_detection_segmentation/ssd/model/ssd-12-int8.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:687696a719e57bb86aabb5fe44b0262cabd5bf26bd82e2698eb14753647632c4
+size 20484185

--- a/vision/object_detection_segmentation/ssd/model/ssd-12-int8.tar.gz
+++ b/vision/object_detection_segmentation/ssd/model/ssd-12-int8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f70dc76cac7618375cdc2f4d4b8a42bea229d2545882df57a3b6cce282515a5
+size 31815039

--- a/vision/object_detection_segmentation/ssd/model/ssd-12.onnx
+++ b/vision/object_detection_segmentation/ssd/model/ssd-12.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ec1e058e666ef980a6213ac40088877865aafb2b6676b9af204b3828e4bb9d5
+size 80366315

--- a/vision/object_detection_segmentation/ssd/model/ssd-12.tar.gz
+++ b/vision/object_detection_segmentation/ssd/model/ssd-12.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43e57501da34abe0c01ea30902303bdb14f590f59c18fbb15ea3473810b0e86b
+size 90592544


### PR DESCRIPTION
<!--- SPDX-License-Identifier: MIT -->

# EfficientNet-Lite4

## Use Cases
EfficientNet-Lite4 is an image classification model that achieves state-of-the-art accuracy. It is designed to run on mobile CPU, GPU, and EdgeTPU devices, allowing for applications on mobile and loT, where computational resources are limited.

## Description
EfficientNet-Lite 4 is the largest variant and most accurate of the set of EfficientNet-Lite model. It is an integer-only quantized model that produces the highest accuracy of all of the EfficientNet models. It achieves 80.4% ImageNet top-1 accuracy, while still running in real-time (e.g. 30ms/image) on a Pixel 4 CPU.

## Model

 |Model        |Download | Download (with sample test data)|ONNX version|Opset version|Top-1 accuracy (%)|
|-------------|:--------------|:--------------|:--------------|:--------------|:--------------|
|EfficientNet-Lite4     | [51.9 MB](model/efficientnet-lite4-11.onnx)	  | [48.6 MB](model/efficientnet-lite4-11.tar.gz)|1.7.0|11|80.4|
|EfficientNet-Lite4-int8     | [13.0 MB](model/efficientnet-lite4-11-int8.onnx)	  | [12.2 MB](model/efficientnet-lite4-11-int8.tar.gz)|1.9.0|11|77.56|
> The fp32 Top-1 accuracy got by [Intel® Neural Compressor](https://github.com/intel/neural-compressor) is 77.70%, and compared with this value, int8 EfficientNet-Lite4's Top-1 accuracy drop ratio is 0.18% and performance improvement is 1.12x.
>
> **Note** 
>
> The performance depends on the test hardware. Performance data here is collected with Intel® Xeon® Platinum 8280 Processor, 1s 4c per instance, CentOS Linux 8.3, data batch size is 1.

### Source
Tensorflow EfficientNet-Lite4 => ONNX EfficientNet-Lite4
ONNX EfficientNet-Lite4 => Quantized ONNX EfficientNet-Lite4

<hr>


## Inference

### Running Inference
The following steps show how to run the inference using onnxruntime.

    import onnxruntime as rt

    # load model
    # Start from ORT 1.10, ORT requires explicitly setting the providers parameter if you want to use execution providers
    # other than the default CPU provider (as opposed to the previous behavior of providers getting set/registered by default
    # based on the build flags) when instantiating InferenceSession.
    # For example, if NVIDIA GPU is available and ORT Python package is built with CUDA, then call API as following:
    # rt.InferenceSession(path/to/model, providers=['CUDAExecutionProvider'])
    sess = rt.InferenceSession(MODEL + ".onnx")
    # run inference
    results = sess.run(["Softmax:0"], {"images:0": img_batch})[0]


### Input to model
Input image to model is resized to shape `float32[1,224,224,3]`. The batch size is 1, with 224 x 224 height and width dimensions. The input is an RBG image that has 3 channels: red, green, and blue. Inference was done using a jpg image.

### Preprocessing steps
The following steps show how to preprocess the input image. For more details visit [this conversion notebook](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/efficientnet-lite.ipynb).

    import numpy as np
    import math
    import matplotlib.pyplot as plt
    import onnxruntime as rt
    import cv2
    import json

    # load the labels text file
    labels = json.load(open("labels_map.txt", "r"))

    # set image file dimensions to 224x224 by resizing and cropping image from center
    def pre_process_edgetpu(img, dims):
        output_height, output_width, _ = dims
        img = resize_with_aspectratio(img, output_height, output_width, inter_pol=cv2.INTER_LINEAR)
        img = center_crop(img, output_height, output_width)
        img = np.asarray(img, dtype='float32')
        # converts jpg pixel value from [0 - 255] to float array [-1.0 - 1.0]
        img -= [127.0, 127.0, 127.0]
        img /= [128.0, 128.0, 128.0]
        return img

    # resize the image with a proportional scale
    def resize_with_aspectratio(img, out_height, out_width, scale=87.5, inter_pol=cv2.INTER_LINEAR):
        height, width, _ = img.shape
        new_height = int(100. * out_height / scale)
        new_width = int(100. * out_width / scale)
        if height > width:
            w = new_width
            h = int(new_height * height / width)
        else:
            h = new_height
            w = int(new_width * width / height)
        img = cv2.resize(img, (w, h), interpolation=inter_pol)
        return img

    # crop the image around the center based on given height and width
    def center_crop(img, out_height, out_width):
        height, width, _ = img.shape
        left = int((width - out_width) / 2)
        right = int((width + out_width) / 2)
        top = int((height - out_height) / 2)
        bottom = int((height + out_height) / 2)
        img = img[top:bottom, left:right]
        return img

    # read the image
    fname = "image_file"
    img = cv2.imread(fname)
    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)

    # pre-process the image like mobilenet and resize it to 224x224
    img = pre_process_edgetpu(img, (224, 224, 3))
    plt.axis('off')
    plt.imshow(img)
    plt.show()

    # create a batch of 1 (that batch size is buned into the saved_model)
    img_batch = np.expand_dims(img, axis=0)

### Output of model
Output of model is an inference score with array shape `float32[1,1000]`. The output references the `labels_map.txt` file which maps an index to a label to classify the type of image.

### Postprocessing steps
The following steps detail how to print the output results of the model.

    # load the model
    # Start from ORT 1.10, ORT requires explicitly setting the providers parameter if you want to use execution providers
    # other than the default CPU provider (as opposed to the previous behavior of providers getting set/registered by default
    # based on the build flags) when instantiating InferenceSession.
    # For example, if NVIDIA GPU is available and ORT Python package is built with CUDA, then call API as following:
    # rt.InferenceSession(path/to/model, providers=['CUDAExecutionProvider'])
    sess = rt.InferenceSession(MODEL + ".onnx")
    # run inference and print results
    results = sess.run(["Softmax:0"], {"images:0": img_batch})[0]
    result = reversed(results[0].argsort()[-5:])
    for r in result:
        print(r, labels[str(r)], results[0][r])
<hr>

## Dataset (Train and validation)
The model was trained using [COCO 2017 Train Images, Val Images, and Train/Val annotations](https://cocodataset.org/#download).
<hr>

## Validation
Refer to [efficientnet-lite4 conversion notebook](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/efficientnet-lite.ipynb) for details of how to use it and reproduce accuracy.
<hr>

## Quantization
CaffeNet-int8 is obtained by quantizing fp32 CaffeNet model. We use [Intel® Neural Compressor](https://github.com/intel/neural-compressor) with onnxruntime backend to perform quantization. View the [instructions](https://github.com/intel/neural-compressor/blob/master/examples/onnxrt/image_recognition/onnx_model_zoo/efficientnet/quantization/ptq/README.md) to understand how to use Intel® Neural Compressor for quantization.

### Environment
onnx: 1.9.0 
onnxruntime: 1.8.0

### Prepare model
```shell
wget https://github.com/onnx/models/raw/master/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx
```

### Model quantize
Make sure to specify the appropriate dataset path in the configuration file.
```bash
bash run_tuning.sh --input_model=path/to/model \  # model path as *.onnx
                   --config=efficientnet.yaml \
                   --output_model=path/to/save
```
<hr>

## References
* Tensorflow to Onnx conversion [tutorial](https://github.com/onnx/tensorflow-onnx/blob/master/tutorials/efficientnet-lite.ipynb). The Juypter Notebook references how to run an evaluation on the efficientnet-lite4 model and export it as a saved model. It also details how to convert the tensorflow model into onnx, and how to run its preprocessing and postprocessing code for the inputs and outputs.

* Refer to this [paper](https://arxiv.org/abs/1905.11946) for more details on the model.

* [Intel® Neural Compressor](https://github.com/intel/neural-compressor)

<hr>

## Contributors
* [Shirley Su](https://github.com/shirleysu8)
* [mengniwang95](https://github.com/mengniwang95) (Intel)
* [airMeng](https://github.com/airMeng) (Intel)
* [ftian1](https://github.com/ftian1) (Intel)
* [hshen14](https://github.com/hshen14) (Intel)

<hr>

## License
MIT License
<hr>