### PR TITLE
Fix idle ONNX/ORT check in CIs: use main branch instead

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install onnx onnxruntime requests
 
-      - name: Test new models by onnxs
+      - name: Test new models by onnx
         run: |
           python workflow_scripts/test_models.py --target onnx
 

--- a/workflow_scripts/test_models.py
+++ b/workflow_scripts/test_models.py
@@ -20,9 +20,9 @@ def main():
 
   cwd_path = Path.cwd()
   # git fetch first for git diff on GitHub Action
-  subprocess.run(['git', 'fetch', 'origin', 'master:master'], cwd=cwd_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  subprocess.run(['git', 'fetch', 'origin', 'main:main'], cwd=cwd_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   # obtain list of added or modified files in this PR
-  obtain_diff = subprocess.Popen(['git', 'diff', '--name-only', '--diff-filter=AM', 'origin/master', 'HEAD'],
+  obtain_diff = subprocess.Popen(['git', 'diff', '--name-only', '--diff-filter=AM', 'origin/main', 'HEAD'],
   cwd=cwd_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   stdoutput, stderroutput = obtain_diff.communicate()
   diff_list = stdoutput.split()


### PR DESCRIPTION
**Description**
Recently onnx/models has changed its default branch to main branch: https://github.com/onnx/models/pull/497. We should also use main branch in the code to prevent issues.

**Motivation**
Currently ONNX/ORT check is not working in CIs