### PR TITLE
Make CI test .tar.gz and .onnx separately

### DIFF
--- a/vision/super_resolution/sub_pixel_cnn_2016/model/super-resolution-103.onnx
+++ b/vision/super_resolution/sub_pixel_cnn_2016/model/super-resolution-103.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85f36ff88cc504a24af5e0602148bc56a8aa09a58eca8c0da2756f3e8186035e
+size 240078

--- a/workflow_scripts/test_models.py
+++ b/workflow_scripts/test_models.py
@@ -2,7 +2,6 @@
 
 import argparse
 import check_model
-import os
 from pathlib import Path
 import subprocess
 import sys
@@ -10,74 +9,78 @@ import test_utils
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Test settings')
-  # default all: test by both onnx and onnxruntime
-  # if target is specified, only test by the specified one
-  parser.add_argument('--target', required=False, default='all', type=str,
-                      help='Test the model by which (onnx/onnxruntime)?',
-                      choices=['onnx', 'onnxruntime', 'all'])
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(description='Test settings')
+    # default all: test by both onnx and onnxruntime
+    # if target is specified, only test by the specified one
+    parser.add_argument('--target', required=False, default='all', type=str,
+                        help='Test the model by which (onnx/onnxruntime)?',
+                        choices=['onnx', 'onnxruntime', 'all'])
+    args = parser.parse_args()
 
-  cwd_path = Path.cwd()
-  # git fetch first for git diff on GitHub Action
-  subprocess.run(['git', 'fetch', 'origin', 'main:main'], cwd=cwd_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-  # obtain list of added or modified files in this PR
-  obtain_diff = subprocess.Popen(['git', 'diff', '--name-only', '--diff-filter=AM', 'origin/main', 'HEAD'],
-  cwd=cwd_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-  stdoutput, stderroutput = obtain_diff.communicate()
-  diff_list = stdoutput.split()
+    cwd_path = Path.cwd()
+    # git fetch first for git diff on GitHub Action
+    subprocess.run(['git', 'fetch', 'origin', 'main:main'],
+                   cwd=cwd_path, stdout=subprocess.PIPE,
+                   stderr=subprocess.PIPE)
+    # obtain list of added or modified files in this PR
+    obtain_diff = subprocess.Popen(['git', 'diff', '--name-only', '--diff-filter=AM', 'origin/main', 'HEAD'],
+                                   subprocess.PIPE, stderr=subprocess.PIPE)
+    stdoutput, _ = obtain_diff.communicate()
+    diff_list = stdoutput.split()
 
-  # identify list of changed onnx models in model Zoo
-  model_list = [str(model).replace("b'","").replace("'", "") for model in diff_list if ".onnx" in str(model)]
-  # run lfs install before starting the tests
-  test_utils.run_lfs_install()
+    # identify list of changed ONNX models in ONXX Model Zoo
+    tar_ext_name = '.tar.gz'
+    onnx_ext_name = '.onnx'
+    model_list = [str(model).replace("b'", "").replace("'", "")
+                  for model in diff_list if onnx_ext_name or tar_ext_name in str(model)]
+    # run lfs install before starting the tests
+    test_utils.run_lfs_install()
 
-  print('\n=== Running ONNX Checker on added models ===\n')
-  # run checker on each model
-  failed_models = []
-  tar_ext_name = '.tar.gz'
-  for model_path in model_list:
-      model_name = model_path.split('/')[-1]
-      tar_name = model_name.replace('.onnx', tar_ext_name)
-      print('==============Testing {}=============='.format(model_name))
+    print('\n=== Running ONNX Checker on added models ===\n')
+    # run checker on each model
+    failed_models = []
+    for model_path in model_list:
+        model_name = model_path.split('/')[-1]
+        print('==============Testing {}=============='.format(model_name))
 
-      try:
-        # Step 1: check the onnx model and test_data_set from .tar.gz by ORT
-        # replace '.onnx' with '.tar.gz'
-        tar_gz_path = model_path[:-5] + '.tar.gz'
-        print(tar_gz_path)
-        test_data_set = []
-        # if tar.gz exists, git pull and try to get test data
-        if (args.target == 'onnxruntime' or args.target == 'all') and os.path.exists(tar_gz_path):
-          test_utils.pull_lfs_file(tar_gz_path)
-          # check whether 'test_data_set_0' exists
-          model_path_from_tar, test_data_set = test_utils.extract_test_data(tar_gz_path)
-          # finally check the onnx model from .tar.gz by ORT
-          # if the test_data_set does not exist, create the test_data_set
-          check_model.run_backend_ort(model_path_from_tar, test_data_set)
-          print('[PASS] {} is checked by onnxruntime. '.format(tar_name))
+        try:
+            # check .tar.gz by ORT and ONNX
+            if tar_ext_name in model_name:
+                # Step 1: check the ONNX model and test_data_set from .tar.gz by ORT
+                test_data_set = []
+                # if tar.gz exists, git pull and try to get test data
+                if (args.target == 'onnxruntime' or args.target == 'all'):
+                    test_utils.pull_lfs_file(model_path)
+                    # check whether 'test_data_set_0' exists
+                    model_path_from_tar, test_data_set = test_utils.extract_test_data(model_path)
+                    # finally check the ONNX model from .tar.gz by ORT
+                    # if the test_data_set does not exist, create the test_data_set
+                    check_model.run_backend_ort(model_path_from_tar, test_data_set)
+                    print('[PASS] {} is checked by onnxruntime. '.format(model_name))
+                # Step 2: check the ONNX model inside .tar.gz by ONNX
+                if args.target == 'onnx' or args.target == 'all':
+                    check_model.run_onnx_checker(model_path_from_tar)
+                    print('[PASS] {} is checked by onnx. '.format(model_name))
+            # check uploaded standalone ONNX model by ONNX
+            elif onnx_ext_name in model_name:
+                test_utils.pull_lfs_file(model_path)
+                if args.target == 'onnx' or args.target == 'all':
+                    check_model.run_onnx_checker(model_path)
+                    print('[PASS] {} is checked by onnx. '.format(model_name))
 
-        # Step 2: check the uploaded onnx model by ONNX
-        # git pull the onnx file
-        test_utils.pull_lfs_file(model_path)
-        # 2. check the uploaded onnx model by ONNX
-        if args.target == 'onnx' or args.target == 'all':
-          check_model.run_onnx_checker(model_path)
-          print('[PASS] {} is checked by onnx. '.format(model_name))
+        except Exception as e:
+            print('[FAIL] {}: {}'.format(model_name, e))
+            failed_models.append(model_path)
+            test_utils.remove_onnxruntime_test_dir()
+            # remove the produced tar directory
+            test_utils.remove_tar_dir()
 
-      except Exception as e:
-        print('[FAIL] {}: {}'.format(model_name, e))
-        failed_models.append(model_path)
-        test_utils.remove_onnxruntime_test_dir()
+    if len(failed_models) == 0:
+        print('{} models have been checked. '.format(len(model_list)))
+    else:
+        print('In all {} models, {} models failed. '.format(len(model_list), len(failed_models)))
+        sys.exit(1)
 
-      # remove the produced tar directory
-      test_utils.remove_tar_dir()
-
-  if len(failed_models) == 0:
-      print('{} models have been checked. '.format(len(model_list)))
-  else:
-      print('In all {} models, {} models failed. '.format(len(model_list), len(failed_models)))
-      sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/workflow_scripts/test_models.py
+++ b/workflow_scripts/test_models.py
@@ -24,7 +24,7 @@ def main():
                    stderr=subprocess.PIPE)
     # obtain list of added or modified files in this PR
     obtain_diff = subprocess.Popen(['git', 'diff', '--name-only', '--diff-filter=AM', 'origin/main', 'HEAD'],
-                                   subprocess.PIPE, stderr=subprocess.PIPE)
+                                   cwd=cwd_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdoutput, _ = obtain_diff.communicate()
     diff_list = stdoutput.split()
 


### PR DESCRIPTION
**Description**
- Make CI test .tar.gz and .onnx separately
- Code cleanup

**Motivation**
Current CI only tests .tar.gz when .onnx exists and even in that case it won't test standalone .onnx. This PR makes it test .tar.gz and .onnx separately. For instance, https://github.com/onnx/models/pull/513 this PR only updates .tar.gz and the CI doesn't test .tar.gz at all.